### PR TITLE
Additional per-vhost options in http termination nginx

### DIFF
--- a/roles/cs.nginx-https-termination/defaults/main.yml
+++ b/roles/cs.nginx-https-termination/defaults/main.yml
@@ -41,6 +41,13 @@ https_termination_page_cache_misses_logfile: "{{ nginx_log_dir }}/access.page-ca
 #   if set this file will be installed on server in the appropriate location
 # - letsencrypt - (optional, default: false) - if true then certs will be
 #   generated using letsencrypt
+# - extra_config - custom config block to add to the vhost file above
+#   the auto-generated main `server` block
+# - extra_vhost_config - custom config block to add inside the
+#   the auto-generated main `server` directive
+# - redirect_aliases - (default: no) - whether the aliases should be redirected
+#   with 301 to the main `server_name`
+# - permanent_path_redirect_map - a map of request patterns to redirect using 301
 #
 # Example config:
 #
@@ -50,9 +57,11 @@ https_termination_page_cache_misses_logfile: "{{ nginx_log_dir }}/access.page-ca
 #      cert_path: "vars/certs/creativestyle.eu.cer"
 #      cert_chain_path: "vars/certs/creativestyle.eu.chain.cer"
 #      cert_key_path: "vars/certs/creativestyle.eu.key"
+#      redirect_aliases: yes
 #    - name: "multialias-letsencrypt"
 #      letsencrypt: yes
 #      server_name: "a-test.creativestyle.eu"
+#      redirect_aliases: no
 #      aliases:
 #       - "b-test.creativestyle.eu"
 #       - "c-test.creativestyle.eu"

--- a/roles/cs.nginx-https-termination/templates/vhost.conf.j2
+++ b/roles/cs.nginx-https-termination/templates/vhost.conf.j2
@@ -1,10 +1,40 @@
+{% if item.extra_config | default('') %}
+# ---  [BEGIN] Custom Project Config [BEGIN]  ---
+{{ varnish_vcl_synth_extra }}
+# ---  [END] Custom Project Config [END]  ---
+{% endif %}
+
+{% set vhost_id = item.name | trim | lower | regex_replace('[^a-z0-9]+', '_') %}
+
+{% if item.permanent_path_redirect_map | default([]) %}
+map $request_uri $perm_redirect_uri_{{ vhost_id }} {
+{% for src, dst in item.permanent_path_redirect_map.items(): %}
+    {{ src }} {{ dst }};
+{% endfor %}
+}
+{% endif %}
+
+{% if redirect_aliases and item.aliases | default([]) %}
+server {
+{% if https_termination_hide_varnish %}
+    listen 80;
+{% endif %}
+
+    listen 443 ssl http2;
+
+    server_name {{ item.aliases | default([])|join(' ') }};
+
+    return 301 $scheme://{{ item.server_name }}$request_uri;
+}
+{% endif %}
+
 server {
 {% if https_termination_hide_varnish %}
     listen 80;
 {% endif %}
 
 {% if item.server_name != '*' %}
-    server_name {{ item.server_name }} {{ item.aliases | default([])|join(' ') }};
+    server_name {{ item.server_name }}{% if not redirect_aliases %} {{ item.aliases | default([])|join(' ') }}{% endif %};
 {% endif %}
 
     listen 443 ssl http2;
@@ -25,7 +55,19 @@ server {
     include "{{ nginx_blacklist_vhost_check_config_file }}";
 {% endif %}
 
-    {{ item.extra_vhost_config | default('') }}
+{% if item.extra_vhost_config | default('') %}
+    # ---  [BEGIN] Custom Project Server Config [BEGIN]  ---
+    {% filter indent(width=4) -%}
+    {{ extra_vhost_config }}
+    {% endfilter %}
+    # ---  [END] Custom Project Server Config [END]  ---
+{% endif %}
+
+{% if item.permanent_path_redirect_map | default([]) %}
+    if ($perm_redirect_uri_{{ vhost_id }}) {
+        return 301 $scheme://$host$perm_redirect_uri_{{ vhost_id }};
+    }
+{% endif %}
 
     location / {
         proxy_pass http://{{ https_termination_varnish_upstream }};


### PR DESCRIPTION
-  Allow to define custom extra config block outside the server directive
-  Allow to automatically redirect server aliases to the primary name
-  Allow to define custom request uri (path) redirect map