### PR TITLE
[IMPROVEMENT] [MOPS-22] Allow employee Limited/Full access roles to v…

### DIFF
--- a/roles/cs.aws-iam-employee-access/templates/employee_full_access.policy.json
+++ b/roles/cs.aws-iam-employee-access/templates/employee_full_access.policy.json
@@ -284,6 +284,13 @@
                 "support:*"
             ],
             "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "aws-marketplace:ViewSubscriptions"
+            ],
+            "Resource": "*"
         }
     ]
 }

--- a/roles/cs.aws-iam-employee-access/templates/employee_limited_access.policy.json
+++ b/roles/cs.aws-iam-employee-access/templates/employee_limited_access.policy.json
@@ -34,6 +34,13 @@
             ],
             "Effect": "Allow",
             "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "aws-marketplace:ViewSubscriptions"
+            ],
+            "Resource": "*"
         }
     ]
 }


### PR DESCRIPTION
…iew Marketplace subscriptions

This is needed in order to manually start EC2 instance with the CentOS AMI we use

Since this is a *read-only* permission I've added it to both roles as Limited should be granted the same access as Full but without any write access. This is to keep things consistent and it might come handy.