### PR TITLE
Feature wakeup on deploy

### DIFF
--- a/roles/cs.aws-node-facts/vars/main.yml
+++ b/roles/cs.aws-node-facts/vars/main.yml
@@ -1,3 +1,7 @@
 aws_node_facts_base_tags: "{{ aws_tags_base }}"
 aws_node_facts_base_filters:
-  instance-state-name: running
+  instance-state-name: 
+    - "running"
+    - "stopped"
+    - "stopping"
+    - "shutting-down"

--- a/roles/cs.aws-node-persistent/defaults/main.yml
+++ b/roles/cs.aws-node-persistent/defaults/main.yml
@@ -5,7 +5,7 @@ aws_ansible_persistent_node_inventory_group: persistent
 aws_persistent_node_instance_name: "{{ mageops_app_name }}-persistent"
 
 aws_persistent_node_launch_script_extra: ''
-
+aws_persistent_instance_id: false
 aws_persistent_node_security_groups:
   - "{{ aws_security_group_ssh_id }}"
 

--- a/roles/cs.aws-node-persistent/tasks/main.yml
+++ b/roles/cs.aws-node-persistent/tasks/main.yml
@@ -1,9 +1,13 @@
-- name: Create persistent node instance
+- name: Start persistent node instance
   ec2:
     region: "{{ aws_region }}"
     monitoring: no
     assign_public_ip: yes
-    exact_count: 1
+    # 2 lines below because of https://github.com/ansible/ansible/issues/20867
+    # otherwise state: running would be ok.
+    state: "{{ aws_persistent_instance_id | ternary('running', omit) }}"
+    exact_count: "{{ aws_persistent_instance_id | ternary(omit, 1) }}"
+    instance_id: "{{ aws_persistent_instance_id | ternary(aws_persistent_instance_id, omit) }}"
     key_name: "{{ aws_ec2_ssh_key_name }}"
     group_id: >-
       {{
@@ -20,7 +24,7 @@
     image: "{{ aws_persistent_node_ami_id }}"
     instance_type: "{{ aws_persistent_node_instance_type }}"
     instance_profile_name: "{{ aws_iam_role_varnish }}"
-    instance_initiated_shutdown_behavior: terminate
+    instance_initiated_shutdown_behavior: stop
     user_data: "{{ aws_ec2_instance_user_data | default(omit, true) }}"
     count_tag: "{{ aws_persistent_node_name_tags }}"
     instance_tags: >-
@@ -53,7 +57,7 @@
   wait_for:
     port: 22
     host: "{{ item.public_ip }}"
-  loop: '{{ aws_persistent_ec2.tagged_instances }}'
+  loop: '{{ aws_persistent_ec2.instances }}'
   loop_control:
     label: "{{ item.public_dns_name }}"
 
@@ -63,14 +67,14 @@
     groupname:
       - persistent
       - "{{ mageops_app_host_group }}"
-  loop: '{{ aws_persistent_ec2.tagged_instances }}'
+  loop: '{{ aws_persistent_ec2.instances }}'
   loop_control:
     label: "{{ item.public_ip }}"
 
 - name: Assign elastic IP to persistent node
   ec2_eip:
     region: "{{ aws_region }}"
-    device_id: "{{ aws_persistent_ec2.tagged_instances[0].id }}"
+    device_id: "{{ aws_persistent_ec2.instances[0].id }}"
     ip: "{{ aws_persistent_node_elastic_ip }}"
   when: aws_persistent_node_elastic_ip | default(false, true)
 

--- a/roles/cs.aws-node-varnish/defaults/main.yml
+++ b/roles/cs.aws-node-varnish/defaults/main.yml
@@ -7,4 +7,4 @@ aws_varnish_node_launch_script_extra: ''
 aws_varnish_node_security_groups:
   - "{{ aws_security_group_ssh_id }}"
   - "{{ aws_security_group_varnish_id }}"
-
+aws_varnish_instance_id: false

--- a/roles/cs.aws-node-varnish/tasks/main.yml
+++ b/roles/cs.aws-node-varnish/tasks/main.yml
@@ -1,16 +1,20 @@
-- name: Create varnish node instance
+- name: Start varnish node instance
   ec2:
     region: "{{ aws_region }}"
     monitoring: no
     assign_public_ip: yes
-    exact_count: 1
+    # 2 lines below because of https://github.com/ansible/ansible/issues/20867
+    # otherwise state: running would be ok.
+    state: "{{ aws_varnish_instance_id | ternary('running', omit) }}"
+    exact_count: "{{ aws_varnish_instance_id | ternary(omit, 1) }}"
+    instance_id: "{{ aws_varnish_instance_id | ternary(aws_varnish_instance_id, omit) }}"
     key_name: "{{ aws_ec2_ssh_key_name }}"
     group_id: "{{ aws_varnish_node_security_groups + varnish_as_loadbalancer | ternary([aws_security_group_lb_id], []) }}"
     vpc_subnet_id: "{{ aws_varnish_node_vpc_subnet_id }}"
     image: "{{ aws_varnish_node_ami_id }}"
     instance_type: "{{ aws_varnish_node_instance_type }}"
     instance_profile_name: "{{ aws_iam_role_varnish }}"
-    instance_initiated_shutdown_behavior: terminate
+    instance_initiated_shutdown_behavior: stop
     user_data: "{{ aws_ec2_instance_user_data | default(omit, true) }}"
     count_tag: "{{ aws_varnish_node_name_tags }}"
     instance_tags: >-
@@ -41,7 +45,7 @@
   wait_for:
     port: 22
     host: "{{ item.public_ip }}"
-  loop: '{{ aws_varnish_ec2.tagged_instances }}'
+  loop: '{{ aws_varnish_ec2.instances }}'
   loop_control:
     label: "{{ item.public_dns_name }}"
 
@@ -53,14 +57,14 @@
       - builder_app
       - builder
       - "{{ mageops_app_host_group }}"
-  loop: '{{ aws_varnish_ec2.tagged_instances }}'
+  loop: '{{ aws_varnish_ec2.instances }}'
   loop_control:
     label: "{{ item.public_ip }}"
 
 - name: Assign elastic IP to varnish node
   ec2_eip:
     region: "{{ aws_region }}"
-    device_id: "{{ aws_varnish_ec2.tagged_instances[0].id }}"
+    device_id: "{{ aws_varnish_ec2.instances[0].id }}"
     ip: "{{ aws_varnish_node_elastic_ip }}"
   when: aws_varnish_node_elastic_ip | default(false, true)
 

--- a/site.step-10-infrastructure-aws.yml
+++ b/site.step-10-infrastructure-aws.yml
@@ -29,10 +29,12 @@
     - role: cs.aws-node-varnish
       aws_varnish_node_root_device: "{{ aws_ami_root_device }}"
       aws_varnish_node_vpc_subnet_id: "{{ aws_vpc_subnet_id }}"
+      aws_varnish_instance_id: "{{ aws_varnish_node_instance.instance_id | default(false) }}"
       when: varnish_standalone
     - role: cs.aws-node-persistent
       aws_persistent_node_root_device: "{{ aws_ami_root_device }}"
       aws_persistent_node_vpc_subnet_id: "{{ aws_vpc_subnet_id }}"
+      aws_persistent_instance_id: "{{ aws_persistent_node_instance.instance_id | default(false) }}"
     - role: cs.mysql-configure
     - role: cs.aws-lambda-varnish
       when: varnish_standalone


### PR DESCRIPTION
Extends the create procedure of persistence/varnish node to wake stopped ones

The previous implementation did not respect the stoped state of those instances. Instances were not woking up, and that was breaking the deployment.
With this change, machines that are stopped will be booted automatically.

Improvement indirectly fixes the problem when the node was in other than the preferred availability zone. Currently, the node will be used. In the past, a new machine was created. 