### PR TITLE
Adds support for custom RDS parameters group

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -390,6 +390,22 @@ aws_rds_instance_type: db.t3.micro
 # Name of this instance
 aws_rds_instance_name: "{{ mageops_app_name }}-db"
 
+# Default configuration tunes for MySQL
+aws_rds_param_group_params_default:
+      log_bin_trust_function_creators: 1
+      max_heap_table_size: 67108864
+      tmp_table_size: 67108864
+      # Force 1 on 1-2G instances.
+      # Force 1-8 on bigger instances.
+      # Value needs to be force because of the described bug. https://bugs.mysql.com/bug.php?id=79379
+      innodb_buffer_pool_instances: 1
+      innodb_buffer_pool_chunk_size: 134217728
+      # 2 * (NumCPUs + NumDisks)
+      innodb_thread_concurrency: 2
+
+# Parameters to tune MySQL configuration
+aws_rds_param_group_params: "{{ aws_rds_param_group_params_default | combine(aws_rds_param_group_params_extra | default({}), recursive=True) }}"
+
 # --------------------------
 # --------  AWS S3  --------
 # --------------------------

--- a/roles/cs.aws-rds/defaults/main.yml
+++ b/roles/cs.aws-rds/defaults/main.yml
@@ -9,4 +9,7 @@ aws_rds_subnet_group_name: "{{ mageops_app_name }}"
 aws_rds_subnet_group_subnets: "{{ aws_vpc_subnet_ids }}"
 aws_rds_security_groups:
   - "{{ aws_security_group_rds_id }}"
-
+aws_rds_param_group_name: "{{ mageops_app_name }}"
+aws_rds_param_group_desc: "MageOps parameter group"
+aws_rds_db_engine_version: 5.7
+aws_rds_param_group_engine: "mysql{{ aws_rds_db_engine_version }}"

--- a/roles/cs.aws-rds/tasks/main.yml
+++ b/roles/cs.aws-rds/tasks/main.yml
@@ -6,6 +6,16 @@
     description: "{{ aws_rds_subnet_group_name }}"
     subnets: "{{ aws_rds_subnet_group_subnets }}"
 
+- name: Create RDS parameter group
+  rds_param_group:
+    state: present
+    region: "{{ aws_region }}"
+    name: "{{ aws_rds_param_group_name }}"
+    description: "{{ aws_rds_param_group_desc }}"
+    engine: "{{ aws_rds_param_group_engine }}"
+    tags: "{{ aws_tags_default }}"
+    params: "{{ aws_rds_param_group_params | default(omit) }}"
+
 - name: Create MySQL RDS
   rds:
     command: create
@@ -13,6 +23,8 @@
     publicly_accessible: true
     instance_name: "{{ aws_rds_instance_name }}"
     db_engine: "{{ aws_rds_db_engine }}"
+    parameter_group: "{{ aws_rds_param_group_name }}"
+    engine_version: "{{ aws_rds_db_engine_version }}"
     size: "{{ aws_rds_storage_size }}"
     instance_type: "{{ aws_rds_instance_type }}"
     username: "{{ mageops_mysql_root_user }}"


### PR DESCRIPTION
Currently, the default engine and default parameter group are used when DB is created.
This is not enough anymore as new Magento creates triggers and we need at least `log_bin_trust_function_creators` to be on.

We shall;l create automatically parameters group and tune things we know shall be tuned

This PR adds the creation of the group and some default settings. 
It also allows specifying the MySQL engine version explicitly. 