### PR TITLE
Fix trigger creation in AWS-lambda-coordinated cronjobs

### DIFF
--- a/roles/cs.aws-autoscaling-triggers/tasks/main.yml
+++ b/roles/cs.aws-autoscaling-triggers/tasks/main.yml
@@ -1,11 +1,29 @@
+
+# Note: We need to remove version suffixes from lambda ARNs as in some cases
+# the facts returned from ansible's AWS lambda module return a versioned ARN
+# which causes the tigger to call the specific version which did not have
+# the policy allowing for it to be called applied yet. Complicated, huh?
+- name: Normalize event target ARNs
+  set_fact:
+    aws_autoscaling_trigger_targets: >-
+      {{
+        aws_autoscaling_trigger_targets | default([])
+          + [ target | combine({'arn': normalized_arn}) ]
+      }}
+  loop: "{{ aws_autoscaling_triggers_list }}"
+  loop_control:
+    loop_var: target
+    label: "{{ target.arn }} -> {{ normalized_arn }}"
+  vars:
+    normalized_arn: "{{ target.arn | regex_replace('^(.*lambda:.*:function:.*):[0-9]+$', '\\1') }}"
+
 - name: Setup autoscaling event trigger
   cloudwatchevent_rule:
     name: "trigger-autoscaling-lambda-{{ mageops_app_name }}"
     region: "{{ aws_region }}"
     state: present
     event_pattern: "{{ aws_autoscaling_event_pattern | to_json }}"
-    targets: "{{ aws_autoscaling_triggers_list }}"
-
+    targets: "{{ aws_autoscaling_trigger_targets }}"
   register: aws_autoscaling_event
 
 - name: Allow autoscaling event handler lambda to be executed by CloudWatch Events


### PR DESCRIPTION
Fixes the problem where on first deploy the lambda's would not be triggered at all.