### PR TITLE
[IMPROVEMENT] Modernize the nginx SSL configuration

### DIFF
--- a/roles/cs.nginx-https-termination/templates/vhost.conf.j2
+++ b/roles/cs.nginx-https-termination/templates/vhost.conf.j2
@@ -9,14 +9,13 @@
 {% macro ssl_config(vhost) %}
     listen 443 ssl http2;
 
-    ssl_protocols TLSv1.1 TLSv1.2;
-    ssl_ciphers ECDH+AESGCM:ECDH+AES256:ECDH+AES128:DHE+AES128:!ADH:!AECDH:!MD5;
-    ssl_prefer_server_ciphers on;
-    ssl_session_cache shared:SSL:20m;
-    ssl_session_timeout 60m;
-
-    ssl_stapling on;
-    ssl_stapling_verify on;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers off;
+    ssl_session_timeout 1d;
+    ssl_session_cache shared:mageops:20m;
+    ssl_session_tickets off;
+    add_header Strict-Transport-Security "max-age=63072000" always;
 
     ssl_certificate {{ https_termination_certificate_dir }}/{{ vhost.name }}.cer;
     ssl_certificate_key {{ https_termination_private_dir }}/{{ vhost.name }}.pem;


### PR DESCRIPTION
- Get rid of TLSv1.1 as we don't need it for compat anymore
- Add TLSv1.3 support
- Set ciphers based on Mozilla's recommendations
- Add HSTS header
- Disable OCSP as we don't need it and it was not fully working anyway
- Prolong SSL session timeout 60minutes -> 1 day