### PR TITLE
[FEATURE] Allow to rewrite JS cookies into first-party cookies

### DIFF
--- a/roles/cs.nginx-https-termination/defaults/main.yml
+++ b/roles/cs.nginx-https-termination/defaults/main.yml
@@ -78,7 +78,7 @@ https_termination_hosts:
 # Internal helper var for storing runtime computed configuration
 https_termination_cfg_vhosts: []
 
-# Rewrite JS cookies into server HTTP-only cookies to work around
+# Rewrite JS cookies into server-created (first party) cookies to work around
 # short expiration time forced on JS cookies by some browsers (Safari, ...).
 # Shall be a mapping between JS cookie name -> HTTP cookie name.
 https_termination_nginx_server_cookie_rewrite_map:

--- a/roles/cs.nginx-https-termination/defaults/main.yml
+++ b/roles/cs.nginx-https-termination/defaults/main.yml
@@ -78,3 +78,12 @@ https_termination_hosts:
 # Internal helper var for storing runtime computed configuration
 https_termination_cfg_vhosts: []
 
+# Rewrite JS cookies into server HTTP-only cookies to work around
+# short expiration time forced on JS cookies by some browsers (Safari, ...).
+# Shall be a mapping between JS cookie name -> HTTP cookie name.
+https_termination_nginx_server_cookie_rewrite_map:
+    # DynamicYield tracking cookie
+    _dyid: _dyid_server
+    # Adtriba tracking cookie
+    atbpdid: atbpdid
+

--- a/roles/cs.nginx-https-termination/defaults/main.yml
+++ b/roles/cs.nginx-https-termination/defaults/main.yml
@@ -81,9 +81,10 @@ https_termination_cfg_vhosts: []
 # Rewrite JS cookies into server-created (first party) cookies to work around
 # short expiration time forced on JS cookies by some browsers (Safari, ...).
 # Shall be a mapping between JS cookie name -> HTTP cookie name.
-https_termination_nginx_server_cookie_rewrite_map:
-    # DynamicYield tracking cookie
-    _dyid: _dyid_server
-    # Adtriba tracking cookie
-    atbpdid: atbpdid
+https_termination_nginx_server_cookie_rewrite_map: []
+
+# Example configuration:
+# https_termination_nginx_server_cookie_rewrite_map:
+#    _dyid: _dyid_server    # DynamicYield tracking cookie
+#    atbpdid: atbpdid       # Adtriba tracking cookie
 

--- a/roles/cs.nginx-https-termination/templates/vhost.conf.j2
+++ b/roles/cs.nginx-https-termination/templates/vhost.conf.j2
@@ -73,6 +73,13 @@ server {
 {% endif %}
 
     location / {
+        {% for cookie_js_name, cookie_server_name in https_termination_nginx_server_cookie_rewrite_map.items() %}
+            {% set cookie_js_name_var  = '$cookie_' ~ cookie_js_name | lower | regex_replace('[^_a-z0-9]', '_') %}
+            if ({{ cookie_js_name_var }}) {
+                add_header "Set-Cookie" "{{ cookie_server_name }}={{ cookie_js_name_var }}; Path=/; Max-Age={{ 60 * 60 * 24 * 365 }}; Secure";
+            }
+        {% endfor %}
+        
         proxy_pass http://{{ https_termination_varnish_upstream }};
 
         proxy_redirect off;


### PR DESCRIPTION
Rewrite JS cookies into server-created (first party) cookies to work around
short expiration time forced on JS cookies by some browsers (Safari, ...).
