### PR TITLE
Explicitly disable PHP user_ini local configuration to mitigate secur…

### DIFF
--- a/roles/cs.php/templates/partials/php-common.ini
+++ b/roles/cs.php/templates/partials/php-common.ini
@@ -58,6 +58,9 @@ default_mimetype = "text/html"
 default_charset = "UTF-8"
 
 doc_root =
+; Disable user's local configuration explicitly as Magento its forcing
+; its defaults on us and its a security	risk above all...
+user_ini.filename =
 user_dir =
 enable_dl = Off
 


### PR DESCRIPTION
Explicitly disable PHP user_ini local configuration to mitigate security risk and prevent Magento from forcing its defaults on us.

Magento started shipping it's own `.user.ini` installed by composer in root and `pub/` dirs since around *2.2.x* and we've completely missed this.

This is a critical fix, not only because of the lower memory limit but most importantly because they extend the `max_exectution_time` to a **30min** what can be catastrophic in case of misbehaving code (blocking many of the scarce resource which are PHP-FPM worker processes).