### PR TITLE
Fix raccoon local dev problems related to STS/varnish/basic auth

### DIFF
--- a/group_vars/vagrant.yml
+++ b/group_vars/vagrant.yml
@@ -61,10 +61,8 @@ php_cli_opcache_file_cache_consistency_checks: 1
 php_display_errors: On
 php_http_request_max_execution_time: 600
 
-varnish_host: 127.0.0.1
-varnish_port: 8080
-varnish_backend_port: 80
-varnish_standalone: false
+
+
 
 mysql_public_root_access: yes
 mysql_mariadb_flavor: yes
@@ -76,6 +74,11 @@ mageops_mysql_host: 127.0.0.1
 mageops_redis_host: 127.0.0.1
 mageops_redis_sessions_host: 127.0.0.1
 mageops_elasticsearch_host: 127.0.0.1
+mageops_varnish_host: 127.0.0.1
+mageops_varnish_port: 8080
+mageops_varnish_backend_port: "{{ nginx_app_port }}"
+
+varnish_standalone: false
 
 magento_mode: default
 magento_redis_cache: yes

--- a/roles/cs.nginx-https-termination/defaults/main.yml
+++ b/roles/cs.nginx-https-termination/defaults/main.yml
@@ -1,4 +1,4 @@
-https_termination_varnish_upstream: "127.0.0.1:{{ varnish_port | default(80) }}"
+https_termination_upstream: "127.0.0.1:{{ varnish_port | default(80) }}"
 https_termination_proxy_read_timeout: 90
 https_termination_hide_varnish: yes
 https_termination_nginx_extra_logging_conf_file: "{{ nginx_confd_dir }}/000-logging-extra.conf"
@@ -9,6 +9,9 @@ https_termination_csr_dir: "{{ https_termination_ssl_dir }}/csr"
 https_termination_letsencrypt_privkey_path: "{{ https_termination_private_dir }}/letsencrypt.pem"
 https_termination_letsencrypt_challenge_dir: .well-known
 https_termination_letsencrypt_challenge_root: "{{ nginx_www_dir }}/letsencrypt/challenge"
+
+# The max-age parameter of the Strict-Transport-Security header
+https_termination_sts_max_age: 63072000
 
 # Testing endpoint
 # https_termination_letsencrypt_acme_directory: https://acme-staging.api.letsencrypt.org/directory

--- a/roles/cs.nginx-https-termination/templates/vhost.conf.j2
+++ b/roles/cs.nginx-https-termination/templates/vhost.conf.j2
@@ -15,7 +15,7 @@
     ssl_session_timeout 1d;
     ssl_session_cache shared:mageops:20m;
     ssl_session_tickets off;
-    add_header Strict-Transport-Security "max-age=63072000" always;
+    add_header Strict-Transport-Security "max-age={{ https_termination_sts_max_age }}" always;
 
     ssl_certificate {{ https_termination_certificate_dir }}/{{ vhost.name }}.cer;
     ssl_certificate_key {{ https_termination_private_dir }}/{{ vhost.name }}.pem;
@@ -80,7 +80,7 @@ server {
             }
         {% endfor %}
         
-        proxy_pass http://{{ https_termination_varnish_upstream }};
+        proxy_pass http://{{ https_termination_upstream }};
 
         proxy_redirect off;
         proxy_set_header Host $host;

--- a/roles/cs.varnish/templates/vcl/acl.vcl.j2
+++ b/roles/cs.varnish/templates/vcl/acl.vcl.j2
@@ -18,7 +18,7 @@ acl purge {
     {% endfor %}
 }
 
-{% if varnish_secure_site  %}
+{% if varnish_secure_site %}
 acl trusted {
     {% for ip in varnish_secure_site_trusted_ips %}
     {% if ip | ipaddr('network') %}

--- a/site.step-40-app-node.yml
+++ b/site.step-40-app-node.yml
@@ -94,6 +94,15 @@
       php_fpm_terminate_timeout: "{{ mageops_http_pipeline_request_timeout_override }}"
 
     - role: cs.varnish
+      varnish_port: "{{ mageops_varnish_port }}"
+      varnish_backend_port: "{{ mageops_varnish_backend_port }}"
+      varnish_secure_site: no # With varnish on app node, nginx shall handle the basic auth
+      varnish_purge_trusted_ips: "{{ (aws_vpc_subnet_prefix is defined) | ternary([aws_vpc_subnet_prefix ~ '.0.0/16'], []) }}"
+      varnish_purge_logging: "{{ mageops_varnish_purge_logging }}"
+      varnish_debug_request_token: "{{ mageops_debug_token }}"
+      varnish_debug_request_query_param_name: "{{ mageops_debug_token_query_param }}"
+      varnish_debug_request_cookie_name: "{{ mageops_debug_token_request_cookie }}"
+      varnish_debug_request_header_name: "{{ mageops_debug_token_http_header }}"
       when: not varnish_standalone
 
     - role: cs.blackfire


### PR DESCRIPTION
Make STS header max-age configurable, pass env configuration to varnish role in app node provisioning.

This is a *critical* fix as these problems prevent local development environments to work properly.

Related internal raccoon configuration changes: https://gitlab.creativestyle.pl/mageops/ansible-vars/vagrant/-/commit/f44cfae6e528f6ff07891100ec4e98b2eacb78c4