### PR TITLE
Fix cookie rewrite

### DIFF
--- a/roles/cs.nginx-https-termination/tasks/002-vhosts.yml
+++ b/roles/cs.nginx-https-termination/tasks/002-vhosts.yml
@@ -78,6 +78,12 @@
     label: "{{ vhost.name }}"
     loop_var: vhost
 
+- name: Install global cookie rewrite maps config
+  template:
+    src: cookie-rewrite-maps.conf.j2
+    dest: "{{ nginx_confd_dir }}/000-cookie-rewrite-maps.conf"
+  notify: Reload nginx configs  
+
 - name: Install vhost config
   template:
     src: vhost.conf.j2
@@ -91,7 +97,12 @@
 
 - name: Register provisioned nginx config files
   set_fact:
-    nginx_config_cleanup_provisioned_files: "{{ nginx_config_cleanup_provisioned_files + https_termination_cfg_vhosts | map(attribute='nginx_conf_file') | list }}"
+    nginx_config_cleanup_provisioned_files: >-
+      {{ 
+        nginx_config_cleanup_provisioned_files 
+          + https_termination_cfg_vhosts | map(attribute='nginx_conf_file') | list 
+          + [ nginx_confd_dir ~ '/000-cookie-rewrite-maps.conf' ]
+      }}
 
 
 

--- a/roles/cs.nginx-https-termination/templates/cookie-rewrite-maps.conf.j2
+++ b/roles/cs.nginx-https-termination/templates/cookie-rewrite-maps.conf.j2
@@ -1,0 +1,10 @@
+# ---  [BEGIN] Cookie rewrite maps [BEGIN]  ---
+# Note: We cannot use the "if" directive as it does not work properly inside location block
+# so instead we map to the new Set-Cookie value if cookie has non-zero length (via ".+" regexp).
+# This way, later in the location block cookie will be set if the new $MAGEOPS_COOKIE_REWRITE_* 
+# variable is not empty and will be skipped otherwise (empty valued headers are skipped).
+{% for cookie_js_name, cookie_server_name in https_termination_nginx_server_cookie_rewrite_map.items() %}
+    {% set cookie_js_bare_var_name = cookie_js_name | lower | regex_replace('[^_a-z0-9]', '_') %}
+    map $cookie_{{ cookie_js_bare_var_name }} $MAGEOPS_COOKIE_REWRITE_{{ cookie_js_bare_var_name }} { ~.+ "{{ cookie_server_name }}=$cookie_{{ cookie_js_bare_var_name }}; Path=/; Max-Age={{ 60 * 60 * 24 * 365 }}; Secure"; default ''; }
+{% endfor %}
+# ---  [END] Custom rewrite maps [END]  ---

--- a/roles/cs.nginx-https-termination/templates/vhost.conf.j2
+++ b/roles/cs.nginx-https-termination/templates/vhost.conf.j2
@@ -30,17 +30,6 @@ map $request_uri $perm_redirect_uri_{{ vhost_id }} {
 {% endif %}
 
 
-# ---  [BEGIN] Cookie rewrite maps [BEGIN]  ---
-# Note: We cannot use the "if" directive as it does not work properly inside location block
-# so instead we map to the new Set-Cookie value if cookie has non-zero length (via ".+" regexp).
-# This way, later in the location block cookie will be set if the new $MAGEOPS_COOKIE_REWRITE_* 
-# variable is not empty and will be skipped otherwise (empty valued headers are skipped).
-{% for cookie_js_name, cookie_server_name in https_termination_nginx_server_cookie_rewrite_map.items() %}
-    {% set cookie_js_bare_var_name = cookie_js_name | lower | regex_replace('[^_a-z0-9]', '_') %}
-    map $cookie_{{ cookie_js_bare_var_name }} $MAGEOPS_COOKIE_REWRITE_{{ cookie_js_bare_var_name }} { ~.+ "{{ cookie_server_name }}=$cookie_{{ cookie_js_bare_var_name }}; Path=/; Max-Age={{ 60 * 60 * 24 * 365 }}; Secure"; default ''; }
-{% endfor %}
-# ---  [END] Custom rewrite maps [END]  ---
-
 {% if vhost.redirect_aliases | default(false) and vhost.aliases | default([]) %}
 server {
 {% if https_termination_hide_varnish %}

--- a/roles/cs.nginx-https-termination/templates/vhost.conf.j2
+++ b/roles/cs.nginx-https-termination/templates/vhost.conf.j2
@@ -29,6 +29,18 @@ map $request_uri $perm_redirect_uri_{{ vhost_id }} {
 }
 {% endif %}
 
+
+# ---  [BEGIN] Cookie rewrite maps [BEGIN]  ---
+# Note: We cannot use the "if" directive as it does not work properly inside location block
+# so instead we map to the new Set-Cookie value if cookie has non-zero length (via ".+" regexp).
+# This way, later in the location block cookie will be set if the new $MAGEOPS_COOKIE_REWRITE_* 
+# variable is not empty and will be skipped otherwise (empty valued headers are skipped).
+{% for cookie_js_name, cookie_server_name in https_termination_nginx_server_cookie_rewrite_map.items() %}
+    {% set cookie_js_bare_var_name = cookie_js_name | lower | regex_replace('[^_a-z0-9]', '_') %}
+    map $cookie_{{ cookie_js_bare_var_name }} $MAGEOPS_COOKIE_REWRITE_{{ cookie_js_bare_var_name }} { ~.+ "{{ cookie_server_name }}=$cookie_{{ cookie_js_bare_var_name }}; Path=/; Max-Age={{ 60 * 60 * 24 * 365 }}; Secure"; default ''; }
+{% endfor %}
+# ---  [END] Custom rewrite maps [END]  ---
+
 {% if vhost.redirect_aliases | default(false) and vhost.aliases | default([]) %}
 server {
 {% if https_termination_hide_varnish %}
@@ -74,10 +86,7 @@ server {
 
     location / {
         {% for cookie_js_name, cookie_server_name in https_termination_nginx_server_cookie_rewrite_map.items() %}
-            {% set cookie_js_name_var  = '$cookie_' ~ cookie_js_name | lower | regex_replace('[^_a-z0-9]', '_') %}
-            if ({{ cookie_js_name_var }}) {
-                add_header "Set-Cookie" "{{ cookie_server_name }}={{ cookie_js_name_var }}; Path=/; Max-Age={{ 60 * 60 * 24 * 365 }}; Secure";
-            }
+            add_header "Set-Cookie" "$MAGEOPS_COOKIE_REWRITE_{{ cookie_js_name | lower | regex_replace('[^_a-z0-9]', '_') }}";
         {% endfor %}
         
         proxy_pass http://{{ https_termination_upstream }};


### PR DESCRIPTION
The feature has been refactored because it only worked for one cookie at once, never returned more than one `Set-Cookie` header.

The "if" directive does not work properly inside the location block (only last one ever catches) so instead I  map the request cookie var to the new Set-Cookie value if the cookie has a non-zero length (via ".+" regexp).

This way, later in the location block cookie will be set if the new $MAGEOPS_COOKIE_REWRITE_* variable is not empty and will be skipped otherwise (empty valued headers are skipped).