### PR TITLE
Remove varnish vars from https termination

### DIFF
--- a/roles/cs.nginx-https-termination/defaults/main.yml
+++ b/roles/cs.nginx-https-termination/defaults/main.yml
@@ -1,4 +1,5 @@
-https_termination_upstream: "127.0.0.1:{{ varnish_port | default(80) }}"
+https_termination_upstream_port: 80
+https_termination_upstream: "127.0.0.1:{{ https_termination_upstream_port }}"
 https_termination_proxy_read_timeout: 90
 https_termination_hide_varnish: yes
 https_termination_nginx_extra_logging_conf_file: "{{ nginx_confd_dir }}/000-logging-extra.conf"

--- a/site.maintenance.update-certificates.yml
+++ b/site.maintenance.update-certificates.yml
@@ -4,7 +4,7 @@
   roles:
     - role: cs.nginx-url-blacklist
     - role: cs.nginx-https-termination
-      varnish_port: "{{ mageops_varnish_port }}"
+      https_termination_upstream_port: "{{ mageops_varnish_port }}"
       when: mageops_https_termination_enable
   vars:
     nginx_blacklist_urls: "{{ nginx_blacklist_urls_default + nginx_blacklist_urls_project | default([]) }}"

--- a/site.step-15-varnish.yml
+++ b/site.step-15-varnish.yml
@@ -40,7 +40,7 @@
       nginx_blacklist_urls: "{{ nginx_blacklist_urls_default + nginx_blacklist_urls_project | default([]) }}"
     - role: cs.nginx
     - role: cs.nginx-https-termination
-      varnish_port: "{{ mageops_varnish_port }}"
+      https_termination_upstream_port: "{{ mageops_varnish_port }}"
       when: mageops_https_termination_enable
     - role: cs.nginx-language-redirect
       when: mageops_language_redirect_enable

--- a/site.step-40-app-node.yml
+++ b/site.step-40-app-node.yml
@@ -86,6 +86,7 @@
     - role: cs.nginx-https-termination
       when: mageops_app_node_https_termination_enable
       nginx_blacklist_urls: "{{ mageops_app_node_https_termination_enable | ternary(mageops_app_node_nginx_blacklist_urls, []) }}"
+      https_termination_upstream_port: "{{ mageops_varnish_port }}"
 
     - role: cs.php-fpm
       tags: php


### PR DESCRIPTION
Vars are replaced by universal names and passed during invocation