### PR TITLE
Add easy way to discover/ssh into ec2 nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,20 @@ across internal creativestyle services thus any leftovers have been removed
 to avoid confusion. New documentation will start appearing shortly as part 
 of this repository succesively.
 
+# Utilities
+
+## Managing current EC2 nodes
+
+```sh
+bin/ec2-ip # Returns IP of app node
+bin/ec2-ip varnish # as above, of varnish node
+bin/ec2-ip persistent # as above, of persistent node
+
+bin/ec2-ssh # SSHs into app node as magento user
+bin/ec2-ssh app # SSHs into app node as magento user
+bin/ec2-ssh root@app # SSHs into app node as root user
+bin/ec2-ssh varnish # SSH into varnish node as root user
+```
 
 <p align="right">
 <em>Brought to life by</em><br/>

--- a/bin/ec2-ip
+++ b/bin/ec2-ip
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+set -e
+
+MAGEOPS_PROJECT="magesuite"
+MAGEOPS_ENVIRONMENT="dev"
+
+function contains() {
+  local n=$#
+  local value=${!n}
+  for ((i=1;i < $#;i++)) {
+    if [ "${!i}" == "${value}" ]; then
+      return 0
+    fi
+  }
+  return 1
+}
+
+TYPES=("app" "varnish" "persistent")
+TYPE=${1:-app}
+if ! contains "${TYPES[@]}" $TYPE; then
+  echo "Usage: bin/ec2-ip app|varnish|persistent"
+  exit 1
+fi
+
+aws ec2 describe-instances  --filters "Name=tag:Role,Values=$MAGEOPS_PROJECT-$MAGEOPS_ENVIRONMENT-$TYPE" | jq '.Reservations[-1].Instances[-1].PublicIpAddress' -r

--- a/bin/ec2-ssh
+++ b/bin/ec2-ssh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -e
+
+MAGEOPS_PROJECT="magesuite"
+MAGEOPS_ENVIRONMENT="dev"
+
+NODE_TYPE=$1
+USER=root
+
+if test "$NODE_TYPE" == "" || test "$NODE_TYPE" == "app"; then
+  NODE_TYPE=app
+  USER=magento
+fi
+
+if [[ $NODE_TYPE == *"@"* ]]; then
+  IFS="@" read USER NODE_TYPE <<< "$1"
+fi
+
+echo "SSHing as $USER into $MAGEOPS_PROJECT-$MAGEOPS_ENVIRONMENT-$NODE_TYPE node"
+
+IP=$(bin/ec2-ip $NODE_TYPE)
+
+ssh $USER@$IP "${@:2}"


### PR DESCRIPTION
I found it quite hard to "find what is the current ec2 node IP and ssh into it", while I think it's something that a dev often needs to do.

So I wrote some simple shell scripts that let you just do it with 1 line.

Let me know if u know a better way to do it and/or would like me to customize it somehow before merging this.