### PR TITLE
Do not overwrite Magento base url redirect setting once set

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -885,6 +885,7 @@ magento_core_config_settings_default:
     path: "web/url/redirect_to_base"
     # Magento config values: 0 - disabled, 1 - 302 redirect, 301 - 301 redirect
     value: "{{ '1' if magento_core_config_enable_redirect_to_base | int == 302 else magento_core_config_enable_redirect_to_base | int | string }}"
+    default: yes
 
   - name: Separate process for default cronjob group
     path: "system/cron/default/use_separate_process"


### PR DESCRIPTION
Fixes MOPS-130:
> Remove magento_core_config_enable_redirect_to_base ansible var and it's functionallity.
>
> Currently we have following ansible variable:
> magento_core_config_enable_redirect_to_base
> https://github.com/mageops/ansible-infrastructure/blob/master/group_vars/all.yml#L866
> 
> It is set by default to "NO", and if any specific project does not have overwritten value for it,
> with every deploy - magento redirect to base URL is being reset to NO.
>
> We don't need this to be reset with every deploy and the magento admin panel should be the only place where we can set this option - therefore please remove this functionality and variable. 

Adding `default: yes` causes that this setting is only set if it's not yet present in `core_config_settings`.

CC: @drabikowy