### PR TITLE
[WIP] hirak/prestissimo is not longer needed with composer 2

### DIFF
--- a/vagrant.yml
+++ b/vagrant.yml
@@ -28,12 +28,6 @@
         - redis
         - varnish
   tasks:
-    - name: Install composer parallel download plugin globally
-      composer:
-        command: require
-        global_command: yes
-        arguments: hirak/prestissimo
-
     - include_tasks: "{{ mageops_project_vars_dir }}/{{ item }}"
       when: vagrant_tasks_project is defined
       loop: "{{ vagrant_tasks_project }}"


### PR DESCRIPTION
We need first new versions of composer plugins, for now we need to downgrade composer to 1.x