### PR TITLE
[MOPS-152] Fix varnish not stripping multiple instances of the same query parameter

### DIFF
--- a/roles/cs.varnish/templates/vcl/subroutines/recv.vcl.j2
+++ b/roles/cs.varnish/templates/vcl/subroutines/recv.vcl.j2
@@ -206,11 +206,13 @@ if (req.http.Accept-Encoding) {
 }
 
 {% for param in varnish_strip_params %}
-# remove all forms of param: {{ param }}
-set req.url = regsuball(req.url,"\?{{ param }}=[^&]+$","");  # strips when QS = "?param=AAA"
-set req.url = regsuball(req.url,"\?{{ param }}=[^&]+&","?"); # strips when QS = "?param=AAA&foo=bar"
+# remove all forms of param: {{ param }} - The order is important!
 set req.url = regsuball(req.url,"&{{ param }}=[^&]+","");    # strips when QS = "?foo=bar&param=AAA" or QS = "?foo=bar&param=AAA&bar=baz"
-
+set req.url = regsuball(req.url,"\?{{ param }}=[^&]+&","?"); # strips when QS = "?param=AAA&foo=bar"
+set req.url = regsuball(req.url,"\?{{ param }}=[^&]+$","");  # strips when QS = "?param=AAA"
 {% endfor %}
 
 return (hash);
+
+    
+    


### PR DESCRIPTION
The solution was to reverse pattern replacement order. It did not work because the first regsub removed the last ampersand
so the final substitution did not ever match.