### PR TITLE
Share var/global across instances to enable maintenance mode.

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1066,10 +1066,12 @@ magento_efs_static_cache_releases_remote_path: "/pub/static/_cache-releases"
 magento_efs_import_data_remote_path: "/import"
 magento_efs_export_data_remote_path: "/export"
 magento_efs_publicly_shared_remote_path: "/pub/shared"
+magento_efs_global_data_remote_path: "/var/global"
 
 magento_efs_import_data_app_path: "{{ mageops_app_web_dir }}/shared/var/import"
 magento_efs_export_data_app_path: "{{ mageops_app_web_dir }}/shared/var/export"
 magento_efs_publicly_shared_app_path: "{{ mageops_app_web_dir }}/shared/pub/shared"
+magento_efs_global_data_app_path: "{{ mageops_app_web_dir }}/shared/var/global"
 
 # EFS resource name
 magento_efs_app_node_name: "{{ mageops_app_name }}-app-shared"

--- a/roles/cs.magento-shared-storage/defaults/main.yml
+++ b/roles/cs.magento-shared-storage/defaults/main.yml
@@ -34,6 +34,8 @@ magento_efs_app_mounts_basic:
     group: "{{ magento_group }}"
   - local_mountpoint: "{{ magento_static_cache_dir }}"
     remote_path: "{{ magento_efs_static_cache_release_remote_path }}"
+  - local_mountpoint: "{{ magento_efs_global_data_app_path }}"
+    remote_path: "{{ magento_efs_global_data_remote_path }}"
     owner: "{{ magento_user }}"
     group: "{{ magento_group }}"
 

--- a/site.step-45-app-deploy.yml
+++ b/site.step-45-app-deploy.yml
@@ -139,6 +139,7 @@
       - 'pub/shared'
       - 'var/import'
       - 'var/export'
+      - 'var/global'
     deploy_shared_dirs: "{{ deploy_shared_dirs_basic + deploy_shared_dirs_extra }}"
     deploy_writable_dirs:
       - "var"


### PR DESCRIPTION
Caution! This requires our Magento Framework patch which changes location of the .maintenance files
to var/global.