### PR TITLE
Improvement adjust nginx fcgi buffers

### DIFF
--- a/roles/cs.nginx-magento/defaults/main.yml
+++ b/roles/cs.nginx-magento/defaults/main.yml
@@ -57,3 +57,24 @@ nginx_debug_request_header_name: X-NGINX-Debug-Token
 nginx_debug_request_info_header_name: X-NGINX-Debug-Info
 
 
+# Note: For performance reasons the buffer sizes must be aligned to (be a multiple
+# of) the system page size which can be safely assumed to be 8k.
+#
+# Following two settings are assigned to `fastcgi_buffers` param effectively
+# controlling the maximum total size of fcgi upstream response read buffers.
+# The total size is roughly equal to the product of both values `chunk_count * chunk_size`.
+# See: http://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_buffers
+nginx_magento_fastcgi_buffers_chunk_count: 16
+nginx_magento_fastcgi_buffers_chunk_size: 256k
+
+# This setting is assigned to `fastcgi_buffer_size` parameter which confusingly
+# controls the size of the buffer that is allocated *initially* when FCGI response
+# is processed. This buffer - among others - holds the response HTTP headers, so
+# it might need to be increased in case of 'too big header' errors.
+#
+# Caution: This value does not allocate a separate buffer, this buffer is allocated
+# from the pool configured above. This value must be smaller than the max buffer size.
+# See: http://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_buffer_size
+nginx_magento_fastcgi_buffers_head_size: 256k
+
+

--- a/roles/cs.nginx-magento/templates/magento_fastcgi_params.conf.j2
+++ b/roles/cs.nginx-magento/templates/magento_fastcgi_params.conf.j2
@@ -14,8 +14,10 @@ fastcgi_param MAGE_RUN_TYPE $MAGE_RUN_TYPE;
 fastcgi_read_timeout {{ nginx_fcgi_read_timeout }};
 fastcgi_connect_timeout {{ nginx_fcgi_connect_timeout }};
 
-fastcgi_buffers 256 16k;
-fastcgi_buffer_size 32k;
+
+
+fastcgi_buffers {{ nginx_magento_fastcgi_buffers_chunk_count }} {{ nginx_magento_fastcgi_buffers_chunk_size }};
+fastcgi_buffer_size {{ nginx_magento_fastcgi_buffers_head_size }};
 
 {% if nginx_magento_fastci_params_extra | default(false, true) %}
 # --- START CUSTOM APPLICATION {{ mageops_app_name }} PARAMS ---


### PR DESCRIPTION
>    The most imporatant change is the increase of fastcgi_buffer_size parameters which
    if set too low will lead to 'too big header' errors, which seem to be relatively
    frequent with Magento.
>    
>    This changes should not have much effect on memory consumption as the total buffer
    size does not change. The number of buffers and size of single one have been swapped
    which should decrease memory fragmentation and maybe even slightly improve performance
    at a negligible (in comparison to PHP memory usage) memory usage increase.
    
~WIP - Still need to test this - in terms of typos mostly, because the parameter adjustment has been already verified in production.~