### PR TITLE
[UPGRADE] Use hardcoded CentOS 7 AMI ids since Martketplace images are no longer updated

### DIFF
--- a/roles/cs.aws-ami-facts/defaults/main.yml
+++ b/roles/cs.aws-ami-facts/defaults/main.yml
@@ -3,10 +3,23 @@ ami_facts_common_filters:
   architecture: "x86_64"
   block-device-mapping.volume-type: "gp2"
 
+# Deprecated - CentOS no longer updates the Marketplace AMIs
+# ami_facts_clean_base_filters:
+#   name: "{{ aws_ami_base_marketplace_name }}"
+#   is-public: "true"
+#   owner-alias: "aws-marketplace"
+
+# The image id of CentOS AWS images needs to be hardcoded and manually update now.
+# Warning! The ids are different for each region, for no we use a hardcoded
+# values for eu-central-1.
+# Find the latest CentOS ami ids here: https://www.centos.org/download/aws-images/
+ami_centos7_id:
+  eu-central-1: ami-08b6d44b4f6f7b279
+
+ami_base_system_image_id: "{{ ami_centos7_id[aws_region | default('eu-central-1')] }}"
+
 ami_facts_clean_base_filters:
-  name: "{{ aws_ami_base_marketplace_name }}"
-  is-public: "true"
-  owner-alias: "aws-marketplace"
+  image-id: "{{ ami_base_system_image_id }}"
 
 ami_facts_app_node_tags: "{{ aws_tags_base | combine(aws_tags_role_app) }}"
 

--- a/roles/cs.aws-ami-facts/tasks/find-clean-base-ami.yml
+++ b/roles/cs.aws-ami-facts/tasks/find-clean-base-ami.yml
@@ -19,3 +19,16 @@
     aws_ami_clean_base_name: "{{ aws_ami_clean_base_info.name }}"
     aws_ami_clean_base_location: "{{ aws_ami_clean_base_info.image_location }}"
     aws_ami_root_device: "{{ aws_ami_clean_base_info.root_device_name }}"
+
+- name: Print information about base AMI found
+  debug:
+    msg: |
+      Clean base AMI information
+      ==========================
+
+      {{ aws_ami_clean_base_name }} [{{ aws_ami_clean_base_id }}]
+      ({{ aws_ami_clean_base_location }})
+
+      --- Details ---
+      
+      {{ aws_ami_clean_base_info | to_nice_yaml }}


### PR DESCRIPTION
CentOS no longer updates the Marketplace AMIs, hence we need to hardcode the AMI ids
and update them manually from https://www.centos.org/download/aws-images/.