### PR TITLE
Add AutoscalingInstanceHealthcheckSelfReport IAM Policy

### DIFF
--- a/roles/cs.aws-iam/defaults/main.yml
+++ b/roles/cs.aws-iam/defaults/main.yml
@@ -5,6 +5,7 @@ aws_iam_name_prefix: MageOps
 aws_iam_policy_s3_access_name: "{{ aws_iam_name_prefix }}S3Access"
 aws_iam_policy_efs_access: "{{ aws_iam_name_prefix }}EFSAccess"
 aws_iam_policy_ec2_list_name: "{{ aws_iam_name_prefix }}EC2List"
+aws_iam_policy_ec2_asg_healtcheck_self_report_name: "{{ aws_iam_name_prefix }}AutoscalingInstanceHealthcheckSelfReport"
 aws_iam_policy_ec2_assign_iam_role: "{{ aws_iam_name_prefix }}EC2AssignIAMRole"
 aws_iam_policy_cloudwatch_logs_access: "{{ aws_iam_name_prefix }}CloudWatchLogsAccess"
 aws_iam_policy_cloudwatch_metrics_access: "{{ aws_iam_name_prefix }}CloudWatchMetricsAccess"

--- a/roles/cs.aws-iam/tasks/ec2-instance-roles.yml
+++ b/roles/cs.aws-iam/tasks/ec2-instance-roles.yml
@@ -38,6 +38,39 @@
     state: present
   register: iam_ec2_list
 
+- name: Create EC2 ASG healthcheck self-report policy
+  iam_managed_policy:
+    policy_name: "{{ aws_iam_policy_ec2_asg_healtcheck_self_report_name }}"
+    policy_description: Allow autoscaled EC2 instances to self-report their healhcheck so they can let ASG know once Magento has warmed up
+    policy: "{{ aws_iam_policy_ec2_asg_healtcheck_self_report | to_json }}"
+    state: present
+  vars:
+    aws_iam_policy_ec2_asg_healtcheck_self_report:
+      Version: '2012-10-17'
+      Statement:
+        - Sid: AnsibleGeneratedRead
+          Effect: Allow
+          Action:
+            - autoscaling:DescribeAutoScalingNotificationTypes
+            - autoscaling:DescribeAutoScalingInstances
+            - autoscaling:DescribeScalingActivities
+            - autoscaling:DescribeAutoScalingGroups
+            - autoscaling:DescribeTags
+          Resource: "*"
+          
+        - Sid: AnsibleGeneratedWrite
+          Effect: Allow
+          Action:
+            - autoscaling:ExitStandby
+            - autoscaling:EnterStandby
+            - autoscaling:CreateOrUpdateTags
+            - autoscaling:SetInstanceHealth
+            - ec2:CreateTags
+          Resource: 
+            - "arn:aws:autoscaling:{{ aws_region }}:{{ aws_account_id }}:autoScalingGroup:*:autoScalingGroupName/*"
+            - "arn:aws:ec2:{{ aws_region }}:{{ aws_account_id }}:instance/*"
+  register: iam_ec2_asg_healtcheck_self_report
+
 - name: Create role for EC2 app instances
   iam_role:
     assume_role_policy_document: "{{ lookup('template', 'ec2_assume_policy_document.json') }}"
@@ -49,6 +82,7 @@
       - "{{ iam_cloudwatch_access.policy.arn }}"
       - "{{ iam_cloudwatch_logs_access.policy.arn }}"
       - "{{ iam_ec2_list.policy.arn }}"
+      - "{{ iam_ec2_asg_healtcheck_self_report.policy.arn }}"
       - "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
 
 - name: Create role for EC2 persistent instances


### PR DESCRIPTION
This policy allows app nodes to manage their own tags and health status
what gives us flexibility to implement quasi-custom dynamic healtchecks
during autoscaling group rolling update and also added more interesting
features like setting custom tags based on current release id.

I was checking what is possible with "custom ASG healthchecks" based
on the available APIs and created this policy "by hand" in IAM console,
decided to implement it quickly so it's not lost. It allows to do really cool
stuff which we can maybe use at some point.

IMO This are non-critical rights to give to an app node. This feature also
doesn't break anything and is not yet needed for anything, so no problem
with merging it or not right now.