### PR TITLE
Upgrade redis to latest stable and supported version 6.x

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1182,7 +1182,7 @@ php_packages:
   - php-curl
   - php-mysqlnd
   - php-pecl-apcu-bc
-  - php-pecl-redis
+  - php-pecl-redis5
   - php-gd
   - php-gmp
   - php-mcrypt

--- a/roles/cs.ansible-plugins/filter_plugins/text.py
+++ b/roles/cs.ansible-plugins/filter_plugins/text.py
@@ -1,0 +1,24 @@
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+
+from ansible.errors import AnsibleError, AnsibleFilterError
+
+import re
+
+''' Strip leading and trailing whitespace from each line
+    while keeping newlines intact '''
+def strip_lines(text, collapse=True):
+    text = re.sub('^[ \t]+|[ \t]+$', '', text, flags=re.MULTILINE)
+    if not collapse:
+        return text
+    return re.sub('[\r\n]{2,}', '\n\n', text, flags=re.DOTALL)
+
+
+class FilterModule(object):
+    def filters(self):
+        return {
+            'strip_lines': strip_lines,
+        }
+

--- a/roles/cs.magento-configure/defaults/main/app-etc.yml
+++ b/roles/cs.magento-configure/defaults/main/app-etc.yml
@@ -111,7 +111,7 @@ magento_app_etc_config_cache_default_redis_l2:
           default:
               backend: \Magento\Framework\Cache\Backend\RemoteSynchronizedCache
               backend_options:
-                  remote_backend: \Magento\Framework\Cache\Backend\Redis
+                  remote_backend: "{{ magento_redis_cache_backend_fqcn }}"
                   remote_backend_options:
                       persistent: 0
                       server: "{{ mageops_redis_host }}"
@@ -136,7 +136,7 @@ magento_app_etc_config_cache_page_redis:
   cache:
     frontend:
       page_cache:
-        backend: Cm_Cache_Backend_Redis
+        backend: "{{ magento_redis_cache_backend_fqcn }}"
         backend_options:
           server: "{{ mageops_redis_host }}"
           database: "1"

--- a/roles/cs.magento-configure/defaults/main/general.yml
+++ b/roles/cs.magento-configure/defaults/main/general.yml
@@ -38,7 +38,18 @@ magento_redis_cache_l2_dir: /dev/shm
 magento_session_max_redis_concurrency: 15
 
 magento_app_etc_config_template: magento_app_etc_config.php.j2
-magento_app_etc_env_template: magento_app_etc_env.php.j2
+
+# Use legacy cache backend class 'Cm_Cache_Backend_Redis'
+# which is the only one available for Magento < 2.3.5 !
+# See: https://devdocs.magento.com/guides/v2.4/config-guide/redis/redis-pg-cache.html#new-redis-cache-implementation
+magento_redis_cache_backend_legacy: yes
+magento_redis_cache_backend_fqcn: >-
+  {{ magento_redis_cache_backend_legacy 
+      | ternary(
+          'Cm_Cache_Backend_Redis', 
+          '\Magento\Framework\Cache\Backend\Redis'
+        ) }}
+
 
 magento_consumer_workers_enable: yes
 magento_consumer_workers:

--- a/roles/cs.redis/defaults/main.yml
+++ b/roles/cs.redis/defaults/main.yml
@@ -1,3 +1,7 @@
+# Install stable redis 6.x from remi-safe repo instead of the 3.x version
+# provided by the standard CentOS 6 epel repository.
+redis_enable_v6: no
+
 # Set it if you want to host multiple redis instances on the same server.
 # This is useful if you want separately-configurable databases (for example with different maxmemory policies)
 # on the same server. Usually you'll want to separate session and cache storage, so cache does not evict sessions.
@@ -15,6 +19,9 @@ redis_bind_interface: 127.0.0.1
 redis_unixsocket: no
 redis_timeout: 300
 
+# If yes then disallow connections without password from other servers
+redis_protected_mode: no
+
 redis_syslog: no
 redis_loglevel: "notice"
 redis_logdir: /var/log/redis
@@ -30,6 +37,12 @@ redis_save:
   - 300 10
   - 60 10000
 
+# The appendonly (AOF) persistence has effect only if the variable
+# `redis_persistence_enable` is enabled (true value).
+redis_appendonly: no
+redis_appendfsync: "everysec"
+redis_appendfilename: appendonly.aof
+
 redis_rdbcompression: "yes"
 redis_dbfilename: dump.rdb
 redis_dbdir: "/var/lib/{{ redis_daemon }}"
@@ -38,8 +51,7 @@ redis_maxmemory: 0
 redis_maxmemory_policy: "noeviction"
 redis_maxmemory_samples: 5
 
-redis_appendonly: "no"
-redis_appendfsync: "everysec"
+
 
 # Add extra include files for local configuration/overrides.
 redis_includes: []

--- a/roles/cs.redis/meta/main.yml
+++ b/roles/cs.redis/meta/main.yml
@@ -1,5 +1,10 @@
 dependencies:
+  - role: cs.ansible-plugins
   - role: cs.repo-epel
+  # Do not enable any repositories permanently except the `safe` default
+  # one because we will enable it explicitly for just this one package.
+  - role: cs.repo-remi
+    when: redis_enable_v6
 
 galaxy_info:
   author: MageOps

--- a/roles/cs.redis/tasks/configure.yml
+++ b/roles/cs.redis/tasks/configure.yml
@@ -32,6 +32,8 @@
   template:
     src: redis.service
     dest: "/etc/systemd/system/{{ redis_daemon }}.service"
+    trim_blocks: yes
+    lstrip_blocks: yes
   notify:
     - Reload systemctl daemon
     - Restart {{ redis_daemon }}

--- a/roles/cs.redis/tasks/install.yml
+++ b/roles/cs.redis/tasks/install.yml
@@ -1,5 +1,9 @@
 - name: Install redis packages
   package:
     name: "{{ redis_package }}"
-    state: present
+    state: "{{ redis_enable_v6 | ternary('latest', 'present') }}"
+    enablerepo: "{{ redis_enable_v6 | ternary('remi,remi-safe', omit) }}"
+  notify:
+    - Reload systemctl daemon
+    - Restart {{ redis_daemon }}
 

--- a/roles/cs.redis/templates/redis.conf
+++ b/roles/cs.redis/templates/redis.conf
@@ -1,67 +1,155 @@
 # {{ ansible_managed }}
 
-daemonize yes
-pidfile {{ redis_pidfile_path }}
+{% filter strip_lines %}
+    daemonize no
+    pidfile {{ redis_pidfile_path }}
 
-{% if redis_port %}
-port {{ redis_port }}
-{% endif %}
+    {% if redis_port %}
+        port {{ redis_port }}
+    {% endif %}
 
-{% if redis_bind_interface %}
-bind {{ redis_bind_interface }}
-{% endif %}
+    {% if redis_bind_interface %}
+        bind {{ redis_bind_interface }}
+    {% endif %}
 
-{% if redis_unixsocket %}
-unixsocket {{ redis_unixsocket }}
-{% endif %}
+    {% if redis_unixsocket %}
+        unixsocket {{ redis_unixsocket }}
+    {% endif %}
 
-timeout {{ redis_timeout }}
+    timeout {{ redis_timeout }}
 
-loglevel {{ redis_loglevel }}
-logfile {{ redis_logfile }}
+    loglevel {{ redis_loglevel }}
+    logfile {{ redis_logfile }}
 
-{% if redis_syslog %}
-syslog-enabled yes
-syslog-ident {{ redis_daemon }}
-syslog-facility local0
-{% endif %}
+    {% if redis_syslog %}
+        syslog-enabled yes
+        syslog-ident {{ redis_daemon }}
+        syslog-facility local0
+    {% endif %}
 
-databases {{ redis_databases }}
+    databases {{ redis_databases }}
 
-{% if redis_persistence_enable %}
+    {% if redis_persistence_enable %}
+        {% for save in redis_save %}
+            save {{ save }}
+        {% endfor %}
 
-{% for save in redis_save %}
-save {{ save }}
-{% endfor %}
+        rdbcompression {{ redis_rdbcompression }}
+        dbfilename {{ redis_dbfilename }}
+        dir {{ redis_dbdir }}
 
-rdbcompression {{ redis_rdbcompression }}
-dbfilename {{ redis_dbfilename }}
-dir {{ redis_dbdir }}
+        {% if redis_appendonly %}
+            appendonly  yes
+            appendfsync {{ redis_appendfsync }}
 
-appendonly {{ redis_appendonly }}
-appendfsync {{ redis_appendfsync }}
-no-appendfsync-on-rewrite no
+            {% if redis_enable_v6 %}
+                appendfilename "{{ redis_appendfilename }}"
+                no-appendfsync-on-rewrite no
 
-{% else %}
-save ""
-{% endif %}
+                aof-load-truncated yes
+                aof-rewrite-incremental-fsync yes
+                aof-use-rdb-preamble yes
+                auto-aof-rewrite-min-size 64mb
+                auto-aof-rewrite-percentage 100
+            {% endif %}
+        {% endif %}
 
-maxclients {{ redis_maxclients }}
+    {% else %}
 
-{% if redis_maxmemory %}
-maxmemory {{ redis_maxmemory }}
-maxmemory-policy {{ redis_maxmemory_policy }}
-maxmemory-samples {{ redis_maxmemory_samples }}
-{% endif %}
+        save ""
+        appendonly no
 
-{% for include in redis_includes %}
-include {{ include }}
-{% endfor %}
+    {% endif %}
 
-{% if redis_requirepass %}
-requirepass {{ redis_requirepass }}
-{% endif %}
+    maxclients {{ redis_maxclients }}
 
-{% for redis_disabled_command in redis_disabled_commands %}
-rename-command {{ redis_disabled_command }} ""
-{% endfor %}
+    {% if redis_maxmemory %}
+        maxmemory {{ redis_maxmemory }}
+        maxmemory-policy {{ redis_maxmemory_policy }}
+        maxmemory-samples {{ redis_maxmemory_samples }}
+    {% endif %}
+
+    {% if redis_requirepass %}
+        requirepass {{ redis_requirepass }}
+    {% endif %}
+
+    {% for redis_disabled_command in redis_disabled_commands %}
+        rename-command {{ redis_disabled_command }} ""
+    {% endfor %}
+
+    {% if redis_enable_v6 %}
+        always-show-logo yes
+        hz 10
+        dynamic-hz yes
+
+        activerehashing yes
+        jemalloc-bg-thread yes
+
+        protected-mode {{ redis_protected_mode | ternary('yes', 'no') }}
+
+        # Performance tuning via: 
+        # - https://devdocs.magento.com/guides/v2.4/config-guide/redis/config-redis.html#config-redis-setup
+        # - http://antirez.com/news/93
+        replica-lazy-flush yes
+        lazyfree-lazy-eviction yes
+        lazyfree-lazy-expire yes
+        lazyfree-lazy-server-del yes
+        lazyfree-lazy-user-del yes
+
+        {#
+        # These are some of the defaults which we don't explicitly set for now
+
+        # latency-monitor-threshold 0
+
+        # client-output-buffer-limit normal 0 0 0
+        # client-output-buffer-limit pubsub 32mb 8mb 60
+        # client-output-buffer-limit replica 256mb 64mb 60
+
+        # list-compress-depth 0
+        # list-max-ziplist-size -2
+
+        # lua-time-limit 1000
+
+        # notify-keyspace-events ""
+
+        # oom-score-adj no
+        # oom-score-adj-values 0 200 800
+
+        # rdb-del-sync-files no
+        # rdb-save-incremental-fsync yes
+
+        # rdbchecksum yes
+        # rdbcompression yes
+
+        # repl-disable-tcp-nodelay no
+        # repl-diskless-load disabled
+        # repl-diskless-sync no
+        # repl-diskless-sync-delay 5
+
+        # replica-lazy-flush no
+        # replica-priority 100
+        # replica-read-only yes
+        # replica-serve-stale-data yes
+
+        # set-max-intset-entries 512
+
+        # slowlog-log-slower-than 10000
+        # slowlog-max-len 128
+
+        # stop-writes-on-bgsave-error yes
+
+        # stream-node-max-bytes 4096
+        # stream-node-max-entries 100
+        
+        # tcp-backlog 511
+        # tcp-keepalive 300
+
+        # zset-max-ziplist-entries 128
+        # zset-max-ziplist-value 64
+        #}
+
+    {% endif %}
+    {% for include in redis_includes %}
+        include {{ include }}
+    {% endfor %}
+{% endfilter %}

--- a/roles/cs.redis/templates/redis.service
+++ b/roles/cs.redis/templates/redis.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Redis persistent key-value database
+
 After=network.target
 After=network-online.target
 Wants=network-online.target
@@ -7,7 +8,7 @@ Wants=network-online.target
 [Service]
 Type=notify
 
-ExecStart=/usr/bin/redis-server {{ redis_conf_path }} --supervised systemd
+ExecStart=/usr/bin/redis-server {{ redis_conf_path }} --daemonize no --supervised systemd
 ExecStop=/usr/libexec/redis-shutdown {{ redis_daemon }}
 
 User=redis
@@ -18,6 +19,11 @@ RuntimeDirectoryMode=0755
 
 RestartSec=3
 Restart=always
+
+TimeoutStartSec=30
+TimeoutStopSec=60
+
+LimitNOFILE=131072
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
> Note: Sorry for the sudden onset of PRs but I've got a lot of smaller/medium
improvements spread across many branches mixed with some crappy commits.
Decided to organize it, slice it, cherry-pick, rebranch so it's not lost.

---

This upgrade has a feature flipper and *is disabled by default*.

We were running redis 3.x from core CentOS repos which is not supported
anymore either by redis or by magento. New Redis provides many improvements
including performance.

Along the upgrade of redis the PECL redis extension has been bumped
to the new `php-pecl-redis5` package. This extension *is fully compatible
with redis 3.x too*, the naming is quite confusing, they have released
this new major version because they have dropped support for PHP 5.x.