### PR TITLE
[IMPROVEMENT] Proper rolling AutoScalingGroup instance refresh

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -422,8 +422,6 @@ aws_extra_app_asg_passthrough_url_pattern:
 aws_extra_app_asg_passthrough_uagent_pattern:
 aws_extra_app_asg_passthrough_ip_pattern:
 
-aws_app_asg_replace_with_check: no
-
 # Example regex to pass bot traffic to the extra instances:
 #aws_extra_app_asg_passthrough_uagent_pattern: "(?i)^alexa|^blitz\\.io|bot|^browsermob|crawl|^curl|^facebookexternalhit|feed|google web preview|^ia_archiver|indexer|^java|jakarta|^libwww-perl|^load impact|^magespeedtest|monitor|^Mozilla$|nagios |^\\.net|^pinterest|postrank|slurp|spider|uptime|^wget|yandex|^elb-healthchecker|binglocalsearch|^Ruby|^python-requests|^Mediapartners-Google|^Sogou"
 

--- a/roles/cs.aws-autoscaling/defaults/main.yml
+++ b/roles/cs.aws-autoscaling/defaults/main.yml
@@ -13,7 +13,7 @@ autoscaling_asg_termination_policies: NewestInstance
 # The minimum time to wait since the node was started until it's considered
 # healthy, attached to the ASG (and next node can be replaced or refresh finished).
 # Note: In other words - it's the time for the node to warm itself up.
-autoscaling_asg_healthcheck_grace_period: 30
+autoscaling_healthcheck_grace_period: 30
 
 ### Built-in AWS rolling ASG instance refresh (update / replacement)
 # The relative minimum amount of instances that must must be up and healthy
@@ -32,11 +32,11 @@ autoscaling_asg_healthcheck_grace_period: 30
 #   at any point in time there will be *at least* 2 healthy instances in the ASG.
 #   Only one can be terminated / replaced at a time, so the full refresh will be
 #   made in 3 steps replacing them one-by-one.
-aws_asg_rolling_instance_refresh_min_healthy_percent: 90
+autoscaling_rolling_instance_refresh_min_healthy_percent: 90
 
 # The extra time to wait for the instance to be warm before replacing the next
-# one - *on top of* the value configured in `autoscaling_asg_healthcheck_grace_period`.
-aws_asg_rolling_instance_refresh_extra_warmup_grace_period: 15
+# one - *on top of* the value configured in `autoscaling_healthcheck_grace_period`.
+autoscaling_rolling_instance_refresh_extra_warmup_grace_period: 15
 
 # Max time to wait for the refresh to complete before giving up (15min default).
 aws_asg_instance_refresh_progress_check_timeout: 900

--- a/roles/cs.aws-autoscaling/defaults/main.yml
+++ b/roles/cs.aws-autoscaling/defaults/main.yml
@@ -7,9 +7,41 @@ autoscaling_instance_tags: {}
 autoscaling_asg_min_size: 1
 autoscaling_asg_max_size: 1
 autoscaling_asg_desired_capacity: 1
-autoscaling_asg_wait_timeout: 1200
 autoscaling_asg_tags: {}
-autoscaling_asg_replace_all: yes
 autoscaling_asg_termination_policies: NewestInstance
-autoscaling_asg_wait_for_instances: yes
-autoscaling_asg_replace_with_check: no
+
+# The minimum time to wait since the node was started until it's considered
+# healthy, attached to the ASG (and next node can be replaced or refresh finished).
+# Note: In other words - it's the time for the node to warm itself up.
+autoscaling_asg_healthcheck_grace_period: 30
+
+### Built-in AWS rolling ASG instance refresh (update / replacement)
+# The relative minimum amount of instances that must must be up and healthy
+# int the ASG at any point in time druing the refresh. (90% is the AWS default)
+#
+# Note: Max capacity does *not* have to be adjusted. AWS ignores it when fullfilling
+# the parameters defined here for the period of refresh.
+#
+# Couple of example cases:
+# - If we have one instance then the default 90% will ensure that this instance
+#   is not killed before the new one is up, healthy and after the grace period.
+# - If this is set to 0 the all old instances are terminated *at once* and new
+#   replacements started.
+# - Assume there are currenty 3 instances in the group and we set this param to
+#   60%. The 60% out of 3 instances translated to the number 2, which means that
+#   at any point in time there will be *at least* 3 healthy instances in the ASG.
+#   Only one can be terminated / replaced at a time, so the full refresh will be
+#   made in 3 steps one-by-one.
+aws_asg_rolling_instance_refresh_min_healthy_percent: 90
+
+# The extra time to wait for the instance to be warm before replacing the next
+# one - *on top of* the value configured in `autoscaling_asg_healthcheck_grace_period`.
+aws_asg_rolling_instance_refresh_extra_warmup_grace_period: 15
+
+# Just common parameters to avoid copy-paster repetition
+aws_asg_instance_refresh_cli_args_base: [
+    --region,       "{{ aws_region }}",
+    --output,       "json",
+    --color,        "off",
+    --no-paginate,
+]

--- a/roles/cs.aws-autoscaling/defaults/main.yml
+++ b/roles/cs.aws-autoscaling/defaults/main.yml
@@ -27,16 +27,24 @@ autoscaling_asg_healthcheck_grace_period: 30
 #   is not killed before the new one is up, healthy and after the grace period.
 # - If this is set to 0 the all old instances are terminated *at once* and new
 #   replacements started.
-# - Assume there are currenty 3 instances in the group and we set this param to
-#   60%. The 60% out of 3 instances translated to the number 2, which means that
-#   at any point in time there will be *at least* 3 healthy instances in the ASG.
+# - Assuming that there are 3 instances in the group and this param is set to
+#   60%. The 60% out of 3 rounded up translates to 2, which means that
+#   at any point in time there will be *at least* 2 healthy instances in the ASG.
 #   Only one can be terminated / replaced at a time, so the full refresh will be
-#   made in 3 steps one-by-one.
+#   made in 3 steps replacing them one-by-one.
 aws_asg_rolling_instance_refresh_min_healthy_percent: 90
 
 # The extra time to wait for the instance to be warm before replacing the next
 # one - *on top of* the value configured in `autoscaling_asg_healthcheck_grace_period`.
 aws_asg_rolling_instance_refresh_extra_warmup_grace_period: 15
+
+# Max time to wait for the refresh to complete before giving up (15min default).
+aws_asg_instance_refresh_progress_check_timeout: 900
+
+# Delay of the retry loop that checks if the refresh has completed. Does not
+# matter much, just the interval between lines are printed. In some CI systems
+# that detects inacticvity you might want to adjust...
+aws_asg_instance_refresh_progress_check_interval: 10
 
 # Just common parameters to avoid copy-paster repetition
 aws_asg_instance_refresh_cli_args_base: [

--- a/roles/cs.aws-autoscaling/tasks/main.yml
+++ b/roles/cs.aws-autoscaling/tasks/main.yml
@@ -33,7 +33,7 @@
     # Grace period for Healthcheck  tatus when new nodes are going up. 
     # The 300s default we had is waaaay too long for our setup and makes the 
     # deploy much, much longer (at least 300s long).
-    health_check_period: "{{ autoscaling_asg_healthcheck_grace_period }}"
+    health_check_period: "{{ autoscaling_healthcheck_grace_period }}"
     termination_policies: "{{ autoscaling_asg_termination_policies }}"
     tags: "{{ aws_tags_default | combine(asg_name_tags, aws_tags_trait_immutable, autoscaling_instance_tags) | dict_to_tag_list }}"
     # This ansible module does not handle instance replacement properly
@@ -57,18 +57,18 @@
       # Note: A futureproof setting - there is no other strategy as of yet.
       Strategy: Rolling
       Preferences:
-          MinHealthyPercentage: "{{ aws_asg_rolling_instance_refresh_min_healthy_percent }}"
-          InstanceWarmup: "{{ aws_asg_rolling_instance_refresh_extra_warmup_grace_period }}"
+          MinHealthyPercentage: "{{ autoscaling_rolling_instance_refresh_min_healthy_percent }}"
+          InstanceWarmup: "{{ autoscaling_rolling_instance_refresh_extra_warmup_grace_period }}"
   register: aws_asg_instance_refresh_command
 
 - name: Compute instance refresh task info
   set_fact:
     aws_asg_instance_refresh_id: "{{ ( aws_asg_instance_refresh_command.stdout | from_json ).InstanceRefreshId }}"
     aws_asg_instance_refresh_estimated_duration: >-
-      {{ ( ( autoscaling_asg_healthcheck_grace_period | int
-          + aws_asg_rolling_instance_refresh_extra_warmup_grace_period | int )
+      {{ ( ( autoscaling_healthcheck_grace_period | int
+          + autoscaling_rolling_instance_refresh_extra_warmup_grace_period | int )
               * autoscaling_asg_desired_capacity | int 
-              * ( aws_asg_rolling_instance_refresh_min_healthy_percent | int + 100 )
+              * ( autoscaling_rolling_instance_refresh_min_healthy_percent | int + 100 )
               / 100 ) | round(1, 'ceil') }}
 
 - name: Print info about refresh id so it can be tracked
@@ -84,10 +84,10 @@
         Est. duration: {{ aws_asg_instance_refresh_estimated_duration }} sec
         Desired capacity: {{ autoscaling_asg_desired_capacity }} instances
 
-        Healthcheck grace period: {{ autoscaling_asg_healthcheck_grace_period }} sec
-        Extra warmup grace period: {{ aws_asg_rolling_instance_refresh_extra_warmup_grace_period }} sec
+        Healthcheck grace period: {{ autoscaling_healthcheck_grace_period }} sec
+        Extra warmup grace period: {{ autoscaling_rolling_instance_refresh_extra_warmup_grace_period }} sec
 
-        Min. healthy: {{ aws_asg_rolling_instance_refresh_min_healthy_percent }} % of instances
+        Min. healthy: {{ autoscaling_rolling_instance_refresh_min_healthy_percent }} % of instances
 
         ---------------------------------------------------
 

--- a/roles/cs.aws-autoscaling/tasks/main.yml
+++ b/roles/cs.aws-autoscaling/tasks/main.yml
@@ -89,6 +89,19 @@
 
         Min. healthy: {{ aws_asg_rolling_instance_refresh_min_healthy_percent }} % of instances
 
+        ---------------------------------------------------
+
+        TIP: Use this shell script to check the status live:
+
+        while sleep 3s ; do aws autoscaling describe-instance-refreshes \
+          --auto-scaling-group-name {{ autoscaling_asg_name }} \
+          --instance-refresh-ids {{ aws_asg_instance_refresh_id }} \
+          | jq -r '.InstanceRefreshes | first | ( [ "[\(now | strftime("%X"))]",
+             "\(.Status) |", "Refresh \(.AutoScalingGroupName) ASG",
+            "- \(.PercentageComplete)% complete", "/ \(.InstancesToUpdate) left",
+            ( if .StatusReason then "(\(.StatusReason))" else "" end ) ] | join(" "))'; \
+        done
+        
       ========================================================
 
 - name: Wait for the rolling Instance Refresh to complete

--- a/roles/cs.aws-autoscaling/tasks/main.yml
+++ b/roles/cs.aws-autoscaling/tasks/main.yml
@@ -26,87 +26,76 @@
     launch_config_name: "{{ launch_configuration.name }}"
     load_balancers: "{{ autoscaling_loadbalancers | default(omit, true) }}"
     min_size: "{{ autoscaling_asg_min_size }}"
-    max_size: >-
-      {{
-        autoscaling_asg_replace_with_check | ternary(
-          autoscaling_asg_max_size + autoscaling_asg_desired_capacity,
-          autoscaling_asg_max_size
-        )
-      }}
-    desired_capacity: >-
-      {{
-        autoscaling_asg_replace_with_check | ternary(
-          autoscaling_asg_desired_capacity * 2,
-          autoscaling_asg_desired_capacity
-        )
-      }}
+    max_size: "{{ autoscaling_asg_max_size }}"
+    desired_capacity: "{{ autoscaling_asg_desired_capacity }}"
     vpc_zone_identifier: "{{ aws_vpc_subnet_id }}"
     default_cooldown: "{{ autoscaling_asg_cooldown }}"
-    wait_for_instances: "{{ autoscaling_asg_wait_for_instances }}"
-    wait_timeout: "{{ autoscaling_asg_wait_timeout }}"
-    replace_all_instances: "{{ autoscaling_asg_replace_all }}"
-    replace_batch_size: "{{ autoscaling_asg_replace_batch_size | default(omit) }}"
+    # Grace period for Healthcheck  tatus when new nodes are going up. 
+    # The 300s default we had is waaaay too long for our setup and makes the 
+    # deploy much, much longer (at least 300s long).
+    health_check_period: "{{ autoscaling_asg_healthcheck_grace_period }}"
     termination_policies: "{{ autoscaling_asg_termination_policies }}"
     tags: "{{ aws_tags_default | combine(asg_name_tags, aws_tags_trait_immutable, autoscaling_instance_tags) | dict_to_tag_list }}"
+    # This ansible module does not handle instance replacement properly
+    # so we just update the ASG configuration here and will perform the
+    # replacement via AWS API in the next steps.
+    replace_instances: []
   vars:
     asg_name_tags:
       - Name: "{{ autoscaling_asg_name }}"
   register: _aws_asg
 
-- name: Handle bulk update of instances with health check
-  block:
-  - name: Make a list od instances for health check
-    ec2_instance_info:
-      region: "{{ aws_region }}"
-      instance_ids: "{{ _aws_asg.instances }}"
-    register: _aws_asg_instances
+  # wait_for_instances: "{{ autoscaling_asg_wait_for_instances }}"
+  # wait_timeout: "{{ autoscaling_asg_wait_timeout }}"
 
-  - name: Wait for nodes to get up (ssh availability)
-    wait_for:
-      port: 22
-      host: "{{ item.public_ip_address }}"
-    loop: "{{ _aws_asg_instances.instances }}"
-    loop_control:
-      label: "{{ item.public_dns_name }}"
-  rescue:
-  # Retry because of race condition when it will return instance that is shutting down
-  # The same thing as in block, because ansible doesn't allow to retry on block
-  - name: Make a list od instances for health check
-    ec2_instance_info:
-      region: "{{ aws_region }}"
-      instance_ids: "{{ _aws_asg.instances }}"
-    register: _aws_asg_instances
+- name: Refresh AutoScaling Group Instances
+  command:
+    argv: >-
+      {{ [ 'aws', 'autoscaling', 'start-instance-refresh' ]
+          + aws_asg_instance_refresh_cli_args_base
+          + [ '--cli-input-json', aws_asg_instance_refresh_params | to_json ] }}
+  vars:
+    aws_asg_instance_refresh_params:
+      AutoScalingGroupName: "{{ autoscaling_asg_name }}"
+      # Note: A futureproof setting - there is no other strategy as of yet.
+      Strategy: Rolling
+      Preferences:
+          MinHealthyPercentage: "{{ aws_asg_rolling_instance_refresh_min_healthy_percent }}"
+          InstanceWarmup: "{{ aws_asg_rolling_instance_refresh_extra_warmup_grace_period }}"
+  register: aws_asg_instance_refresh_command
 
-  - name: Wait for nodes to get up (ssh availability)
-    wait_for:
-      port: 22
-      host: "{{ item.public_ip_address }}"
-    loop: "{{ _aws_asg_instances.instances }}"
-    loop_control:
-      label: "{{ item.public_dns_name }}"
-  when: autoscaling_asg_replace_with_check
+- name: Get the current refresh task identifier
+  set_fact:
+    aws_asg_instance_refresh_id: "{{ ( aws_asg_instance_refresh_command.stdout | from_json ).InstanceRefreshId }}"
 
-- name: Reduce AutoScaling Group - remove old instances
-  ec2_asg:
-    state: present
-    name: "{{ autoscaling_asg_name }}"
-    region: "{{ aws_region }}"
-    min_size: "{{ autoscaling_asg_min_size }}"
-    max_size: "{{ autoscaling_asg_max_size }}"
-    desired_capacity: "{{ autoscaling_asg_desired_capacity }}"
-    termination_policies: >-
-      {{
-        [ 'OldestLaunchConfiguration' ]
-        + (autoscaling_asg_termination_policies is string | ternary(
-              [ autoscaling_asg_termination_policies ],
-              autoscaling_asg_termination_policies
-            )
-          )
-      }}
-    wait_for_instances: yes
-    replace_all_instances: yes
-  register: _aws_asg
-  when: autoscaling_asg_replace_with_check
+- name: Print info about refresh id so it can be tracked
+  debug:
+    msg: |
+      Started ASG rolling instance refresh with id:
+      {{ aws_asg_instance_refresh_id }}
+
+- name: Wait for the AutoScaling Group Instance Refresh to complete
+  command:
+    argv: >-
+      {{ [ 'aws', 'autoscaling', 'describe-instance-refreshes' ]
+          + aws_asg_instance_refresh_cli_args_base
+          + [ '--cli-input-json', aws_asg_instance_describe_refresh_params | to_json ] }}
+  vars:
+    aws_asg_instance_describe_refresh_params:
+      AutoScalingGroupName: "{{ autoscaling_asg_name }}"
+      InstanceRefreshIds: [ "{{ aws_asg_instance_refresh_id }}" ]
+    aws_asg_instance_describe_data: >- 
+      {{ ( aws_asg_describe_instance_refresh_command.stdout 
+            | default('{"Status": null, "PercentageComplete": -1}') | from_json ).InstanceRefreshes | first }}
+  register: aws_asg_describe_instance_refresh_command
+  until: >-
+    aws_asg_describe_instance_refresh_command is not failed 
+    and aws_asg_instance_describe_data.PercentageComplete | default(-1, true) | int == 100
+      and aws_asg_instance_describe_data.Status == 'Successful'
+  loop_control:
+    label: "{{ item }}"
+  delay: 15
+  retries: 60
 
 - name: Create ASG Termination Lifecycle Hook
   ec2_asg_lifecycle_hook:
@@ -118,13 +107,3 @@
     heartbeat_timeout: 120
     default_result: CONTINUE
   when: autoscaling_webnodedown_hook_create
-
-- name: Wait for desired capacity
-  when: autoscaling_asg_desired_capacity | int > 0
-  ec2_asg_info:
-    name: "{{ autoscaling_asg_name }}"
-    region: "{{ aws_region }}"
-  register: _asg_info
-  until: "_asg_info.results and (_asg_info.results[0].instances | length > 0) and (_asg_info.results[0].instances | length) == _asg_info.results[0].desired_capacity"
-  retries: 300
-  delay: 5

--- a/roles/cs.aws-autoscaling/tasks/main.yml
+++ b/roles/cs.aws-autoscaling/tasks/main.yml
@@ -45,9 +45,6 @@
       - Name: "{{ autoscaling_asg_name }}"
   register: _aws_asg
 
-  # wait_for_instances: "{{ autoscaling_asg_wait_for_instances }}"
-  # wait_timeout: "{{ autoscaling_asg_wait_timeout }}"
-
 - name: Refresh AutoScaling Group Instances
   command:
     argv: >-
@@ -64,17 +61,37 @@
           InstanceWarmup: "{{ aws_asg_rolling_instance_refresh_extra_warmup_grace_period }}"
   register: aws_asg_instance_refresh_command
 
-- name: Get the current refresh task identifier
+- name: Compute instance refresh task info
   set_fact:
     aws_asg_instance_refresh_id: "{{ ( aws_asg_instance_refresh_command.stdout | from_json ).InstanceRefreshId }}"
+    aws_asg_instance_refresh_estimated_duration: >-
+      {{ ( ( autoscaling_asg_healthcheck_grace_period | int
+          + aws_asg_rolling_instance_refresh_extra_warmup_grace_period | int )
+              * autoscaling_asg_desired_capacity | int 
+              * ( aws_asg_rolling_instance_refresh_min_healthy_percent | int + 100 )
+              / 100 ) | round(1, 'ceil') }}
 
 - name: Print info about refresh id so it can be tracked
   debug:
-    msg: |
-      Started ASG rolling instance refresh with id:
-      {{ aws_asg_instance_refresh_id }}
+    msg: |-
+      ========================================================
+      =         Started ASG rolling instance refresh!        =
+      ========================================================
 
-- name: Wait for the AutoScaling Group Instance Refresh to complete
+        Group: {{ autoscaling_asg_name }}
+
+        Operation id: {{ aws_asg_instance_refresh_id }}
+        Est. duration: {{ aws_asg_instance_refresh_estimated_duration }} sec
+        Desired capacity: {{ autoscaling_asg_desired_capacity }} instances
+
+        Healthcheck grace period: {{ autoscaling_asg_healthcheck_grace_period }} sec
+        Extra warmup grace period: {{ aws_asg_rolling_instance_refresh_extra_warmup_grace_period }} sec
+
+        Min. healthy: {{ aws_asg_rolling_instance_refresh_min_healthy_percent }} % of instances
+
+      ========================================================
+
+- name: Wait for the rolling Instance Refresh to complete
   command:
     argv: >-
       {{ [ 'aws', 'autoscaling', 'describe-instance-refreshes' ]
@@ -86,16 +103,17 @@
       InstanceRefreshIds: [ "{{ aws_asg_instance_refresh_id }}" ]
     aws_asg_instance_describe_data: >- 
       {{ ( aws_asg_describe_instance_refresh_command.stdout 
-            | default('{"Status": null, "PercentageComplete": -1}') | from_json ).InstanceRefreshes | first }}
+            | default('{"Status": null, "PercentageComplete": -1}') 
+            | from_json ).InstanceRefreshes | first }}
   register: aws_asg_describe_instance_refresh_command
   until: >-
     aws_asg_describe_instance_refresh_command is not failed 
-    and aws_asg_instance_describe_data.PercentageComplete | default(-1, true) | int == 100
+    and aws_asg_instance_describe_data.PercentageComplete | default(0, true) | int == 100
       and aws_asg_instance_describe_data.Status == 'Successful'
-  loop_control:
-    label: "{{ item }}"
-  delay: 15
-  retries: 60
+  delay: "{{ aws_asg_instance_refresh_progress_check_interval }}"
+  retries: >- 
+    {{ ( aws_asg_instance_refresh_progress_check_timeout | int 
+          / aws_asg_instance_refresh_progress_check_interval | int ) | int }}
 
 - name: Create ASG Termination Lifecycle Hook
   ec2_asg_lifecycle_hook:

--- a/roles/cs.aws-autoscaling/tasks/main.yml
+++ b/roles/cs.aws-autoscaling/tasks/main.yml
@@ -45,88 +45,11 @@
       - Name: "{{ autoscaling_asg_name }}"
   register: _aws_asg
 
-- name: Refresh AutoScaling Group Instances
-  command:
-    argv: >-
-      {{ [ 'aws', 'autoscaling', 'start-instance-refresh' ]
-          + aws_asg_instance_refresh_cli_args_base
-          + [ '--cli-input-json', aws_asg_instance_refresh_params | to_json ] }}
-  vars:
-    aws_asg_instance_refresh_params:
-      AutoScalingGroupName: "{{ autoscaling_asg_name }}"
-      # Note: A futureproof setting - there is no other strategy as of yet.
-      Strategy: Rolling
-      Preferences:
-          MinHealthyPercentage: "{{ autoscaling_rolling_instance_refresh_min_healthy_percent }}"
-          InstanceWarmup: "{{ autoscaling_rolling_instance_refresh_extra_warmup_grace_period }}"
-  register: aws_asg_instance_refresh_command
-
-- name: Compute instance refresh task info
-  set_fact:
-    aws_asg_instance_refresh_id: "{{ ( aws_asg_instance_refresh_command.stdout | from_json ).InstanceRefreshId }}"
-    aws_asg_instance_refresh_estimated_duration: >-
-      {{ ( ( autoscaling_healthcheck_grace_period | int
-          + autoscaling_rolling_instance_refresh_extra_warmup_grace_period | int )
-              * autoscaling_asg_desired_capacity | int 
-              * ( autoscaling_rolling_instance_refresh_min_healthy_percent | int + 100 )
-              / 100 ) | round(1, 'ceil') }}
-
-- name: Print info about refresh id so it can be tracked
-  debug:
-    msg: |-
-      ========================================================
-      =         Started ASG rolling instance refresh!        =
-      ========================================================
-
-        Group: {{ autoscaling_asg_name }}
-
-        Operation id: {{ aws_asg_instance_refresh_id }}
-        Est. duration: {{ aws_asg_instance_refresh_estimated_duration }} sec
-        Desired capacity: {{ autoscaling_asg_desired_capacity }} instances
-
-        Healthcheck grace period: {{ autoscaling_healthcheck_grace_period }} sec
-        Extra warmup grace period: {{ autoscaling_rolling_instance_refresh_extra_warmup_grace_period }} sec
-
-        Min. healthy: {{ autoscaling_rolling_instance_refresh_min_healthy_percent }} % of instances
-
-        ---------------------------------------------------
-
-        TIP: Use this shell script to check the status live:
-
-        while sleep 3s ; do aws autoscaling describe-instance-refreshes \
-          --auto-scaling-group-name {{ autoscaling_asg_name }} \
-          --instance-refresh-ids {{ aws_asg_instance_refresh_id }} \
-          | jq -r '.InstanceRefreshes | first | ( [ "[\(now | strftime("%X"))]",
-             "\(.Status) |", "Refresh \(.AutoScalingGroupName) ASG",
-            "- \(.PercentageComplete)% complete", "/ \(.InstancesToUpdate) left",
-            ( if .StatusReason then "(\(.StatusReason))" else "" end ) ] | join(" "))'; \
-        done
-        
-      ========================================================
-
-- name: Wait for the rolling Instance Refresh to complete
-  command:
-    argv: >-
-      {{ [ 'aws', 'autoscaling', 'describe-instance-refreshes' ]
-          + aws_asg_instance_refresh_cli_args_base
-          + [ '--cli-input-json', aws_asg_instance_describe_refresh_params | to_json ] }}
-  vars:
-    aws_asg_instance_describe_refresh_params:
-      AutoScalingGroupName: "{{ autoscaling_asg_name }}"
-      InstanceRefreshIds: [ "{{ aws_asg_instance_refresh_id }}" ]
-    aws_asg_instance_describe_data: >- 
-      {{ ( aws_asg_describe_instance_refresh_command.stdout 
-            | default('{"Status": null, "PercentageComplete": -1}') 
-            | from_json ).InstanceRefreshes | first }}
-  register: aws_asg_describe_instance_refresh_command
-  until: >-
-    aws_asg_describe_instance_refresh_command is not failed 
-    and aws_asg_instance_describe_data.PercentageComplete | default(0, true) | int == 100
-      and aws_asg_instance_describe_data.Status == 'Successful'
-  delay: "{{ aws_asg_instance_refresh_progress_check_interval }}"
-  retries: >- 
-    {{ ( aws_asg_instance_refresh_progress_check_timeout | int 
-          / aws_asg_instance_refresh_progress_check_interval | int ) | int }}
+- name: Perform Rolling Instance Refresh
+  include_tasks: refresh-instances.yml
+  when: >-
+    _aws_asg is changed
+      and autoscaling_asg_desired_capacity > 0
 
 - name: Create ASG Termination Lifecycle Hook
   ec2_asg_lifecycle_hook:

--- a/roles/cs.aws-autoscaling/tasks/refresh-instances.yml
+++ b/roles/cs.aws-autoscaling/tasks/refresh-instances.yml
@@ -1,0 +1,82 @@
+- name: Refresh AutoScaling Group Instances
+  command:
+    argv: >-
+      {{ [ 'aws', 'autoscaling', 'start-instance-refresh' ]
+          + aws_asg_instance_refresh_cli_args_base
+          + [ '--cli-input-json', aws_asg_instance_refresh_params | to_json ] }}
+  vars:
+    aws_asg_instance_refresh_params:
+      AutoScalingGroupName: "{{ autoscaling_asg_name }}"
+      # Note: A futureproof setting - there is no other strategy as of yet.
+      Strategy: Rolling
+      Preferences:
+          MinHealthyPercentage: "{{ autoscaling_rolling_instance_refresh_min_healthy_percent }}"
+          InstanceWarmup: "{{ autoscaling_rolling_instance_refresh_extra_warmup_grace_period }}"
+  register: aws_asg_instance_refresh_command
+
+- name: Compute instance refresh task info
+  set_fact:
+    aws_asg_instance_refresh_id: "{{ ( aws_asg_instance_refresh_command.stdout | from_json ).InstanceRefreshId }}"
+    aws_asg_instance_refresh_estimated_duration: >-
+      {{ ( ( autoscaling_healthcheck_grace_period | int
+          + autoscaling_rolling_instance_refresh_extra_warmup_grace_period | int )
+              * autoscaling_asg_desired_capacity | int 
+              * ( autoscaling_rolling_instance_refresh_min_healthy_percent | int + 100 )
+              / 100 ) | round(1, 'ceil') }}
+
+- name: Print info about refresh id so it can be tracked
+  debug:
+    msg: |-
+      ========================================================
+      =         Started ASG rolling instance refresh!        =
+      ========================================================
+
+        Group: {{ autoscaling_asg_name }}
+
+        Operation id: {{ aws_asg_instance_refresh_id }}
+        Est. duration: {{ aws_asg_instance_refresh_estimated_duration }} sec
+        Desired capacity: {{ autoscaling_asg_desired_capacity }} instances
+
+        Healthcheck grace period: {{ autoscaling_healthcheck_grace_period }} sec
+        Extra warmup grace period: {{ autoscaling_rolling_instance_refresh_extra_warmup_grace_period }} sec
+
+        Min. healthy: {{ autoscaling_rolling_instance_refresh_min_healthy_percent }} % of instances
+
+        ---------------------------------------------------
+
+        TIP: Use this shell script to check the status live:
+
+        while sleep 3s ; do aws autoscaling describe-instance-refreshes \
+          --auto-scaling-group-name {{ autoscaling_asg_name }} \
+          --instance-refresh-ids {{ aws_asg_instance_refresh_id }} \
+          | jq -r '.InstanceRefreshes | first | ( [ "[\(now | strftime("%X"))]",
+             "\(.Status) |", "Refresh \(.AutoScalingGroupName) ASG",
+            "- \(.PercentageComplete)% complete", "/ \(.InstancesToUpdate) left",
+            ( if .StatusReason then "(\(.StatusReason))" else "" end ) ] | join(" "))'; \
+        done
+        
+      ========================================================
+
+- name: Wait for the rolling Instance Refresh to complete
+  command:
+    argv: >-
+      {{ [ 'aws', 'autoscaling', 'describe-instance-refreshes' ]
+          + aws_asg_instance_refresh_cli_args_base
+          + [ '--cli-input-json', aws_asg_instance_describe_refresh_params | to_json ] }}
+  vars:
+    aws_asg_instance_describe_refresh_params:
+      AutoScalingGroupName: "{{ autoscaling_asg_name }}"
+      InstanceRefreshIds: [ "{{ aws_asg_instance_refresh_id }}" ]
+    aws_asg_instance_describe_data: >- 
+      {{ ( aws_asg_describe_instance_refresh_command.stdout 
+            | default('{"Status": null, "PercentageComplete": -1}') 
+            | from_json ).InstanceRefreshes | first }}
+  register: aws_asg_describe_instance_refresh_command
+  until: >-
+    aws_asg_describe_instance_refresh_command is not failed 
+    and aws_asg_instance_describe_data.PercentageComplete | default(0, true) | int == 100
+      and aws_asg_instance_describe_data.Status == 'Successful'
+  delay: "{{ aws_asg_instance_refresh_progress_check_interval }}"
+  retries: >- 
+    {{ ( aws_asg_instance_refresh_progress_check_timeout | int 
+          / aws_asg_instance_refresh_progress_check_interval | int ) | int }}

--- a/site.step-60-autoscaling.yml
+++ b/site.step-60-autoscaling.yml
@@ -57,7 +57,7 @@
       autoscaling_instance_start_script: |
         {{ aws_app_node_launch_script_extra }}
         {{ magento_live_release_dir }}{{ magento_node_warmup_script_path }}
-        {% if not magento_aws_ondemand_import_instance_enable and magento_import_dispatcher_enable %}{{ magento_import_dispatcher_switch_script_path }} on{% endif %}
+        {% if not magento_aws_ondemand_import_instance_enable and magento_import_dispatcher_enable %}{{ magento_import_dispatcher_switch_script_path }} on{% endif %}a
 
     - role: cs.aws-autoscaling
       when: aws_extra_app_asg_enable or magento_aws_ondemand_import_instance_enable

--- a/site.step-60-autoscaling.yml
+++ b/site.step-60-autoscaling.yml
@@ -29,9 +29,6 @@
       autoscaling_asg_max_size: "{{ aws_app_asg_max_size }}"
       autoscaling_asg_cooldown: "{{ aws_app_asg_cooldown }}"
 
-      autoscaling_asg_replace_all: "{{ not aws_app_asg_replace_with_check }}"
-      autoscaling_asg_replace_with_check: "{{ aws_app_asg_replace_with_check }}"
-
       autoscaling_instance_ami_id: "{{ aws_ami_app_node_id}}"
       autoscaling_instance_type: "{{ aws_app_node_instance_type_forced | default(aws_app_node_instance_type, true) }}"
       autoscaling_instance_security_groups: "{{ aws_app_node_security_group_ids }}"


### PR DESCRIPTION
Since the Ansible module for this is very buggy and basically tries to perform this
whole logic "in software" by polling for the states of multiple partial operations.

This PR replaces the broken and unmaintained `ec2_asg` module's instance refresh
mechanism, instead performing it directly using AWS API calls (with the help of aws-cli).

There is basically one API call needed and it does the whole job, start to finish perfectly
without any intervention.

After refresh is started the play just waits until the operation reports 100% completion
status in order to know when the instances are ready which works way better than before.

The whole thing seems to be working perfectly.