### PR TITLE
Minor (but important) nginx hotfixes

### DIFF
--- a/roles/cs.nginx-https-termination/tasks/main.yml
+++ b/roles/cs.nginx-https-termination/tasks/main.yml
@@ -25,5 +25,3 @@
 - name: Setup automatically renewed ACME certificates
   import_tasks: 034-certificates-acme.yml
 
-- name: Ensure changes take effect
-  meta: flush_handlers

--- a/roles/cs.nginx-https-termination/templates/nginx.vhost.conf
+++ b/roles/cs.nginx-https-termination/templates/nginx.vhost.conf
@@ -1,6 +1,6 @@
 {% if vhost.conf_custom_block %}
 # ---  [BEGIN] Custom Project Config [BEGIN]  ---
-{{ vhost.conf_custom }}
+{{ vhost.conf_custom_block }}
 # ---  [END] Custom Project Config [END]  ---
 {% endif %}
 
@@ -114,11 +114,11 @@ server {
         {% endif %}
 
         {% if vhost.server_location_config %}
-        # ---  [BEGIN] Custom Project Server Config [BEGIN]  ---
+        # ---  [BEGIN] Custom Project Location Config [BEGIN]  ---
         {% filter indent(width=8) -%}
         {{ vhost.server_location_config }}
         {% endfilter %}
-        # ---  [END] Custom Project Server Config [END]  ---
+        # ---  [END] Custom Project Location Config [END]  ---
         {% endif %}
 
         include {{ vhost.conf_fragment_dir }}/*.conf;

--- a/roles/cs.nginx/handlers/main.yml
+++ b/roles/cs.nginx/handlers/main.yml
@@ -1,9 +1,17 @@
-- name: Reload nginx configs
+- name: Cleanup nginx configs
   include_tasks: 099-cleanup.yml
   when: nginx_config_cleanup
+  listen:
+    - Reload nginx configs
 
 - name: Restart nginx
-  service: name=nginx state=restarted
+  service:
+    name: nginx
+    state: restarted
 
 - name: Reload nginx
-  service: name=nginx state=reloaded
+  service:
+    name: nginx
+    state: reloaded
+  listen:
+    - Reload nginx configs


### PR DESCRIPTION
From 3609f3da86c899c0f23ca7b0ccb75f6248921380:
> [HOTFIX] Fix typo in nginx vhost template
> 
> Also: fix comment indicating location custom config.

From 56e488f361d713913daf556e7dee2985ad74027c:
>  [HOTFIX] Guarantee nginx is reloaded after conf change
> 
> On nginx config file change we called the "Reload nginx configs" handler,
> however, it did trigger nginx reload unless there was a file to remove.
> 
> The expected behaviour when calling this handler is to reload nginx.
> regardless of whether any cleanup was performed or not.