### PR TITLE
[IMPROVEMENT] Improve zram/vmtouch/swap handling

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -657,12 +657,28 @@ mageops_install_development_tools: yes
 # setup language redirect
 mageops_language_redirect_enable: no
 
-# Tune sysctl to reduce iops
-mageops_reduce_iops: "{{ aws_use }}"
+# Configure a vmtouch daemon force-keeping magento sources / compiled opcache in RAM
+mageops_magento_preload_fscache_enable: >-
+  {{ ( ansible_memtotal_mb | default(512, true) | int >= 7168 ) 
+        and php_cli_opcache_file_cache_enable | default(false, true) }}
+
+# Tune Linux Virtual Memory kernel sysctl params for lower disk IO
+mageops_app_node_optimize_kernel_vm_io: yes
+
+# Enable zram swap device on app nodes
+mageops_app_node_zram_enable: >-
+  {{ ansible_memtotal_mb | default(512, true) | int <= 3072 }}
+
+# Size of zram device relative to total system memory
+mageops_app_node_zram_size_relative: 0.6
 
 # App node swap config
-mageops_swap_app_node_enable: yes
-mageops_zram_app_node_enable: "{{ mageops_reduce_iops }}"
+mageops_app_node_swap_enable: yes
+
+# Set minimal swapping if have only on-disk swapfile and increase to moderate
+# moderate swapping if we have zram (which has bigger priority than the swapfile).
+mageops_app_node_swappiness: >-
+  {{ mageops_app_node_zram_enable | ternary(50, 25) }}
 
 # Secret token used for accessing internal non-sensitive APIs and debugging
 # facilities.

--- a/roles/cs.magento-preload-fscache/defaults/main.yml
+++ b/roles/cs.magento-preload-fscache/defaults/main.yml
@@ -1,3 +1,6 @@
+# Enable+start or disable+stop the services
+magento_preload_fscache_enable: yes
+
 # Max open file descriptors limit for service - greater then the expected
 # number of preloaded files.
 magento_fscache_preload_nproc: 49152

--- a/roles/cs.magento-preload-fscache/tasks/main.yml
+++ b/roles/cs.magento-preload-fscache/tasks/main.yml
@@ -1,3 +1,17 @@
+# TODO: Remove once we're made sure the old `magento-preload.service` is finally gone
+- name: Make sure the previous version of the service is disabled and stopped 
+  shell: >-
+    systemctl --no-legend --no-pager --plain \
+        list-unit-files magento-preload.service \
+            | cut -d' ' -f1 \
+            | while read unit ; do \
+                systemctl disable --now $unit ; \
+            done
+
+  register: magento_preload_cleanup_legacy
+  changed_when: magento_preload_cleanup_legacy.stdout_lines | default([], true) | length > 0
+  failed_when: no
+
 - name: Install vmtouch for preloading fs cache
   yum:
     name: vmtouch
@@ -9,24 +23,15 @@
     dest: "/etc/systemd/system/{{ unit }}"
   loop_control:
     loop_var: unit
-  loop:
-    - magento-preload-sources.service
-    - magento-preload-sources-watcher.service
-    - magento-preload-sources-watcher.timer
-    - magento-preload-sources-watcher.path
+  loop: "{{ magento_preload_fscache_systemd_units }}"
 
 - name: Enable and restart magento source fs cache preloader systemd units
   systemd:
     name: "{{ unit }}"
-    state: restarted
-    enabled: yes
+    state: "{{ mageops_magento_preload_fscache_enable | ternary('restarted', 'stopped') }}"
+    enabled: "{{ mageops_magento_preload_fscache_enable }}"
     daemon_reexec: yes
     daemon_reload: yes
   loop_control:
     loop_var: unit
-  loop:
-    - magento-preload-sources.service
-    - magento-preload-sources-watcher.service
-    - magento-preload-sources-watcher.timer
-    - magento-preload-sources-watcher.path
-    
+  loop: "{{ magento_preload_fscache_systemd_units }}"

--- a/roles/cs.magento-preload-fscache/vars/main.yml
+++ b/roles/cs.magento-preload-fscache/vars/main.yml
@@ -1,0 +1,5 @@
+magento_preload_fscache_systemd_units:
+  - magento-preload-sources.service
+  - magento-preload-sources-watcher.service
+  - magento-preload-sources-watcher.timer
+  - magento-preload-sources-watcher.path

--- a/roles/cs.swap/defaults/main.yml
+++ b/roles/cs.swap/defaults/main.yml
@@ -1,6 +1,9 @@
 # swap size in MB
 swap_size: 1024
 
+# How likely system is to use this swap device over others (e.g. zram)
+swap_file_priority: -100
+
 # usually don't change unless you want to put it on different, faster drive
 swap_file_location: /swapfile
 

--- a/roles/cs.swap/tasks/main.yml
+++ b/roles/cs.swap/tasks/main.yml
@@ -15,14 +15,14 @@
       lineinfile:
         dest: /etc/fstab
         regexp: "{{ swap_file_location }}"
-        line: "{{ swap_file_location }} none swap sw 0 0"
+        line: "{{ swap_file_location }} none swap sw,pri={{ swap_file_priority }} 0 0"
 
     - name: Drop all vm caches # Prevent memory error when enabling swapfile
       shell: echo 3 > /proc/sys/vm/drop_caches 
       changed_when: false
 
     - name: Enable swap file
-      command: "swapon -a"
+      command: "swapon -p {{ swap_file_priority }} {{ swap_file_location }}"
       retries: 3
       delay: 30
       register: _enabled_swap_cmd_result

--- a/roles/cs.zram/defaults/main.yml
+++ b/roles/cs.zram/defaults/main.yml
@@ -2,5 +2,7 @@
 # Avg compression level is 3:1
 # Rule of thumb: set it to 3/4 of available memory
 # this will consume 1/4 or real memory
-#
-zram_size: 768M
+
+zram_swap_priority: 100
+zram_size_relative: 0.5
+zram_size: "{{ ( ansible_memtotal_mb | int * zram_size_relative | float ) | int }}MB"

--- a/roles/cs.zram/templates/zram.rules.j2
+++ b/roles/cs.zram/templates/zram.rules.j2
@@ -1,1 +1,1 @@
-KERNEL=="zram0", SUBSYSTEM=="block", DRIVER=="", ACTION=="add", ATTR{disksize}=="0", ATTR{disksize}="{{ zram_size }}", RUN+="/sbin/mkswap $env{DEVNAME}" RUN+="/sbin/swapon -p 10 $env{DEVNAME}"
+KERNEL=="zram0", SUBSYSTEM=="block", DRIVER=="", ACTION=="add", ATTR{disksize}=="0", ATTR{disksize}="{{ zram_size }}", RUN+="/sbin/mkswap $env{DEVNAME}" RUN+="/sbin/swapon -p {{ zram_swap_priority }} $env{DEVNAME}"

--- a/site.step-40-app-node.yml
+++ b/site.step-40-app-node.yml
@@ -26,11 +26,16 @@
 
     - role: pinkeen.selinux-disable
 
-    - role: cs.swap
-      when: mageops_swap_app_node_enable
-
     - role: cs.zram
-      when: mageops_zram_app_node_enable
+      zram_size_relative: "{{ mageops_app_node_zram_size_relative }}"
+      when: mageops_app_node_zram_enable
+
+    - role: cs.optimize-vm-disk-io
+      when: mageops_app_node_optimize_kernel_vm_io
+
+    - role: cs.swap
+      swap_swappiness: "{{ mageops_app_node_swappiness }}"
+      when: mageops_app_node_swap_enable
 
     - role: cs.earlyoom
       when: mageops_earlyoom_enable
@@ -134,8 +139,10 @@
       when: aws_use
 
     - role: cs.mageops-cli-profile
+
     - role: cs.magerun
       when: mageops_install_magerun
+
     - role: cs.monitoring
       monitoring_node_exporter_enabled: yes
       monitoring_php_fpm_exporter_enabled: yes

--- a/site.step-45-app-deploy.yml
+++ b/site.step-45-app-deploy.yml
@@ -105,11 +105,8 @@
 
     - role: cs.aws-magento-cron
 
-    - role: cs.optimize-vm-disk-io
-      when: mageops_reduce_iops
-
     - role: cs.magento-preload-fscache
-      when: mageops_reduce_iops
+      magento_preload_fscache_enable: "{{ mageops_magento_preload_fscache_enable }}"
 
     - role: cs.magento-import-dispatcher
       when: magento_import_dispatcher_enable


### PR DESCRIPTION
Since the php-cli-opcache contained improvements to the vmtouch/preload
mechanism merging it had the consequence of reenabling the vmoutch by
default which is not desireable anymore.

A more fine-grained switches for zram/fscache-preload/kernel-vm/swap
parameters have been implemented with default "smart" mechanism which
should enable/disable those feature based on the parameters of the
target node.