### PR TITLE
Fix cors origins generation

### DIFF
--- a/roles/cs.aws-s3/tasks/main.yml
+++ b/roles/cs.aws-s3/tasks/main.yml
@@ -19,6 +19,10 @@
     s3_bucket_tags:
       Name: "{{ aws_s3_secret_bucket }}"
 
+- name: Check if allowed cors origins are set
+  set_fact:
+    aws_s3_generate_allowed_origins: "{{ aws_s3_media_bucket_cors_allowed_origins is not defined }}"
+
 - name: Enable CORS for Media bucket
   block:
     - name: Collect all app hosts for allowed origins
@@ -39,7 +43,7 @@
           set_fact:
             aws_s3_media_bucket_cors_allowed_origins: "{{ aws_s3_media_bucket_cors_allowed_origins + [lb_domain] }}"
           when: aws_elb_create | default(false) and lb_domain is defined and lb_domain | length
-      when: aws_s3_media_bucket_cors_allowed_origins is not defined
+      when: aws_s3_generate_allowed_origins
 
     - name: Apply CORS configuration for Media bucket
       aws_s3_cors:

--- a/roles/cs.varnish/tasks/000-facts.yml
+++ b/roles/cs.varnish/tasks/000-facts.yml
@@ -49,6 +49,10 @@
   set_fact:
     varnish_throttling_enabled: "{{ (varnish_standalone and varnish_throttling and varnish_throttling_rules | length > 0)|bool }}"
 
+- name: Check if allowed cors origins are set
+  set_fact:
+    varnish_generate_allowed_origins: "{{ varnish_media_cors_allowed_origins is not defined }}"
+
 - name: Collect all app hosts for allowed origins
   block:
     - name: Collect main Magento installation host
@@ -63,5 +67,4 @@
               https_termination_hosts | default([])|selectattr('aliases', 'defined')|map(attribute='aliases')|list | flatten
           }}
       when: mageops_https_termination_enable | default(false)
-  when: varnish_media_cors_allowed_origins is not defined
-
+  when: varnish_generate_allowed_origins


### PR DESCRIPTION
Ansible `when` condition for blocks work by adding condition
to each task in block.
In this case this causes that first task create fresh variable
and all other ones are no longer executed.