### PR TITLE
Remove broken and uneeded local ssh key authorization code

### DIFF
--- a/group_vars/vagrant.yml
+++ b/group_vars/vagrant.yml
@@ -93,7 +93,6 @@ sshd_public_network_lockdown: yes
 sshd_trusted_networks: "{{ ['127.0.0.0/8'] + mageops_trusted_cidr_blocks }}"
 
 mageops_cli_user_groups: [wheel]
-mageops_cli_user_authorize_local_key: yes
 
 mageops_packages_mirrorlist_countrycode: pl
 mageops_packages_vagrant_node:
@@ -107,5 +106,3 @@ mageops_packages_vagrant_node:
 nodejs_use_yarn: yes
 nodejs_packages:
   - gulp-cli
-
-mageops_authorize_local_keys: yes

--- a/roles/cs.mageops-cli-user/defaults/main.yml
+++ b/roles/cs.mageops-cli-user/defaults/main.yml
@@ -1,6 +1,5 @@
 mageops_cli_user_group: "{{ mageops_cli_user }}"
 mageops_cli_user_groups: []
-mageops_cli_user_authorize_local_key: no
 mageops_cli_user_authorized_keys: []
 mageops_cli_user_ssh_config: no
 mageops_cli_user_default_editor: nano

--- a/roles/cs.mageops-cli-user/tasks/main.yml
+++ b/roles/cs.mageops-cli-user/tasks/main.yml
@@ -52,11 +52,6 @@
     group: "{{ mageops_cli_user_group }}"
   loop: "{{ mageops_cli_user_bashrc_fragments_default + mageops_cli_user_bashrc_fragments }}"
 
-- name: Authorize local ssh key
-  tags: ssh_keys
-  authorized_key: user="{{ mageops_cli_user }}" key="{{ lookup('file', '~/.ssh/id_rsa.pub') }}"
-  when: mageops_cli_user_authorize_local_key
-
 - name: Authorize ssh keys
   tags: ssh_keys
   authorized_key:


### PR DESCRIPTION
It was used only in vagrant and it has been superseded by cs.authorize-local-keys role anyway.