### PR TITLE
Update rabbitmq

### DIFF
--- a/roles/cs.mageops-cli-profile/templates/002-mageops-env.sh
+++ b/roles/cs.mageops-cli-profile/templates/002-mageops-env.sh
@@ -20,5 +20,5 @@ export MAGEOPS_MAGENTO_GROUP="{{ magento_group }}"
 export MAGEOPS_MAGENTO_VERSION="{{ magento_version }}"
 {% endif %}
 
-export MAGEOPS_PS1="\[\e[0;35m\][${MAGEOPS_NODE_ROLE}.${MAGEOPS_PROJECT}-${MAGEOPS_ENVIRONMENT}]\[\e[0m\] "
-export MAGEOPS_PS1="${MAGEOPS_PS1}\[\e[0;33m\]\u\[\e[0;32m\]@\h\[\e[0m\] \[\e[0;94m\]\w\[\e[0m\] \[\e[1;32m\]->\[\e[0m\] "
+export PS1="\[\e[0;35m\][${MAGEOPS_NODE_ROLE}.${MAGEOPS_PROJECT}-${MAGEOPS_ENVIRONMENT}]\[\e[0m\] "
+export PS1="${PS1}\[\e[0;33m\]\u\[\e[0;32m\]@\h\[\e[0m\] \[\e[0;94m\]\w\[\e[0m\] \[\e[1;32m\]→\[\e[0m\] "

--- a/roles/cs.mageops-cli-profile/templates/002-mageops-env.sh
+++ b/roles/cs.mageops-cli-profile/templates/002-mageops-env.sh
@@ -21,7 +21,4 @@ export MAGEOPS_MAGENTO_VERSION="{{ magento_version }}"
 {% endif %}
 
 export MAGEOPS_PS1="\[\e[0;35m\][${MAGEOPS_NODE_ROLE}.${MAGEOPS_PROJECT}-${MAGEOPS_ENVIRONMENT}]\[\e[0m\] "
-export MAGEOPS_PS1="${MAGEOPS_PS1}\[\e[0;33m\]\u\[\e[0;32m\]@\h\[\e[0m\] \[\e[0;94m\]\w\[\e[0m\] \[\e[1;32m\]→\[\e[0m\] "
-
-
-
+export MAGEOPS_PS1="${MAGEOPS_PS1}\[\e[0;33m\]\u\[\e[0;32m\]@\h\[\e[0m\] \[\e[0;94m\]\w\[\e[0m\] \[\e[1;32m\]->\[\e[0m\] "

--- a/roles/cs.mageops-cli-user/templates/bashrc
+++ b/roles/cs.mageops-cli-user/templates/bashrc
@@ -81,9 +81,5 @@ if [[ -d "$HOME/.bashrc.d/" ]] ; then
 	done
 fi
 
-export PS1="$MAGEOPS_PS1"
-
 # Terminal tab name
 export PROMPT_COMMAND='echo -ne "\033]0;$(whoami)@${MAGEOPS_NODE_ROLE}.${MAGEOPS_PROJECT}-${MAGEOPS_ENVIRONMENT}\007"'
-
-

--- a/roles/cs.rabbitmq/defaults/main.yml
+++ b/roles/cs.rabbitmq/defaults/main.yml
@@ -1,8 +1,5 @@
-rabbitmq_server_version: "rabbitmq-server-3.7.9-1.el{{ rabbitmq_el_release }}"
-rabbitmq_erlang_version: "erlang-21.3.7-1.el{{ rabbitmq_el_release }}"
-
-# No other options are supported right now as our repos support EL7 only
-rabbitmq_el_release: 7
+rabbitmq_server_version: "rabbitmq-server-3.8.16"
+rabbitmq_erlang_version: "erlang-23.3.2"
 
 # Ensure the nodename is not auto-generated so we can use various tools
 rabbitmq_nodename: rabbit


### PR DESCRIPTION
Upgrade rabbitmq and fix issue in newer versions of rabbitmq that was caused by utf8 character in MAGEOPS_PS1 environment variable.

removing this variable by setting PS1 dirrectly fixed issue without removing arrow from prompt.

@pinkeen Can we remove server and erlang versions lock now? AFAIK this bug was only thing that forced us lock in the first place