### PR TITLE
Fix cloudfront caching issue with missing content-length

### DIFF
--- a/roles/cs.varnish/templates/vcl/subroutines/backend_fetch.vcl.j2
+++ b/roles/cs.varnish/templates/vcl/subroutines/backend_fetch.vcl.j2
@@ -1,6 +1,6 @@
-# Disable compression for css and js files to prevent chunked response encodig
+# Disable compression for static and media files to prevent chunked response encodig
 # We need content-length in response headers to validate that we can safely cache
 # this resource forever
-if (bereq.url ~ "^/static/.*\.(css|js)(\?.*)?$") {
+if (bereq.url ~ "^/(static|media)/.*$") {
     set bereq.http.Accept-Encoding = "identity";
 }


### PR DESCRIPTION
gzip compression in nginx server causes responding with chunked connection
this strips content-length from response
and this causes varnish to not allow caching (our workaround)