### PR TITLE
Restart magento warmup service on failure

### DIFF
--- a/roles/cs.magento-configure/templates/magento-node-warmup.service
+++ b/roles/cs.magento-configure/templates/magento-node-warmup.service
@@ -10,14 +10,11 @@ Requires=php-fpm.service
 
 ConditionPathExists=!{{ magento_live_release_dir }}/pub/WARMUP
 
-StartLimitIntervalSec=60s
-StartLimitBurst=5
-
 [Service]
-Type=oneshot
+Type=simple
 RemainAfterExit=no
 Restart=on-failure
-RestartSec=5s
+RestartSec=30s
 
 ExecStartPre={{ magento_live_release_dir }}/bin/magento setup:db:status
 ExecStart={{ magento_live_release_dir }}/bin/magento cs:warm-node \

--- a/roles/cs.magento-configure/templates/magento-node-warmup.service
+++ b/roles/cs.magento-configure/templates/magento-node-warmup.service
@@ -13,6 +13,8 @@ ConditionPathExists=!{{ magento_live_release_dir }}/pub/WARMUP
 [Service]
 Type=oneshot
 RemainAfterExit=no
+Restart=on-failure
+RestartSec=5s
 
 ExecStartPre={{ magento_live_release_dir }}/bin/magento setup:db:status
 ExecStart={{ magento_live_release_dir }}/bin/magento cs:warm-node \

--- a/roles/cs.magento-configure/templates/magento-node-warmup.service
+++ b/roles/cs.magento-configure/templates/magento-node-warmup.service
@@ -10,6 +10,9 @@ Requires=php-fpm.service
 
 ConditionPathExists=!{{ magento_live_release_dir }}/pub/WARMUP
 
+StartLimitIntervalSec=60s
+StartLimitBurst=5
+
 [Service]
 Type=oneshot
 RemainAfterExit=no


### PR DESCRIPTION
When warmup fails on boot because of temporary issues
it is never retried, and node remains non functional
until manual intervention

This fix will try to restart warmup process until it succeed