### PR TITLE
Add retry logic for varnish

### DIFF
--- a/roles/cs.varnish/defaults/main.yml
+++ b/roles/cs.varnish/defaults/main.yml
@@ -172,3 +172,7 @@ varnish_301_cache_time: 3h
 # If you are on varnish_trusted_ips list you will
 # still receive those headers
 varnish_do_not_expose_caching: no
+
+# Retry this many times for 503 error from backend (no workers awailable)
+# before bailing out with error
+varnish_max_retries: 4

--- a/roles/cs.varnish/templates/varnish.service.overrides.conf
+++ b/roles/cs.varnish/templates/varnish.service.overrides.conf
@@ -15,10 +15,11 @@ Restart=always
 ExecStart=
 ExecStart=/usr/sbin/varnishd \
     -p "vcl_cooldown=1" \
+    -p "max_retries={{ varnish_max_retries }}" \
 {%- for key, val in varnish_params.items(): %}
     -p "{{ key }}={{ val }}" \
 {%- endfor %}
-	-P "{{ varnish_pid_file }}" \
-	-f "{{ varnish_vcl_conf }}" \
-	-a "{{ varnish_listen_address | default('', true) }}:{{ varnish_port }}" \
-	-s "{{ varnish_storage }},{{ varnish_storage_mem }}"
+    -P "{{ varnish_pid_file }}" \
+    -f "{{ varnish_vcl_conf }}" \
+    -a "{{ varnish_listen_address | default('', true) }}:{{ varnish_port }}" \
+    -s "{{ varnish_storage }},{{ varnish_storage_mem }}"

--- a/roles/cs.varnish/templates/vcl/subroutines/backend_error.vcl.j2
+++ b/roles/cs.varnish/templates/vcl/subroutines/backend_error.vcl.j2
@@ -5,5 +5,9 @@ if (beresp.status == 503) {
     set beresp.http.Pragma = "no-cache";
     set beresp.http.Expires = "0";
 
-    return (deliver);
+    if(bereq.retries == {{ varnish_max_retries }}) {
+        return (deliver);
+    } else {
+        return (retry);
+    }
 }


### PR DESCRIPTION
This will retry request if we receive 503 from backend
meaning that we didn't had awailable workers.
This should aways be safe, because this means that
request never started processing.