### PR TITLE
Disable deprecation index

### DIFF
--- a/roles/cs.elasticsearch/tasks/main.yml
+++ b/roles/cs.elasticsearch/tasks/main.yml
@@ -183,3 +183,7 @@
     port: "{{ elasticsearch_http_port }}"
     delay: 6
     timeout: 60
+
+- name: Fix deprecation indexes
+  shell: >-
+    for index in $(curl -s http://localhost:9200/_cat/shards?format=json | jq -r '.[] | select(.state == "UNASSIGNED") | select(.index | startswith(".ds-.logs")) | .index');do echo -e "\nFixing $index: ";curl -s -XPUT "http://localhost:9200/$index/_settings" -H "Content-Type: application/json" --data '{"index": {"number_of_replicas": 0}}' ;done;echo

--- a/roles/cs.elasticsearch/templates/elasticsearch.yml
+++ b/roles/cs.elasticsearch/templates/elasticsearch.yml
@@ -10,6 +10,10 @@ cluster.name: {{ elasticsearch_cluster_name }}
 cluster.initial_master_nodes: ["{{ elasticsearch_node_name }}"]
 {% endif %}
 
+{% if elasticsearch_version_number is version('7.16.0', '>=') %}
+cluster.deprecation_indexing.enabled: false
+{% endif %}
+
 path.data: /var/lib/elasticsearch
 path.logs: /var/log/elasticsearch
 
@@ -22,5 +26,3 @@ node.data: true
 node.master: true
 
 bootstrap.memory_lock: {{ elasticsearch_memlock_enable | ternary('true', 'false') }}
-
-


### PR DESCRIPTION
Run index fixing script as after disabling deprecation indexing,
there is no documented way to remove them
other than clearubg elasticsearch data