### PR TITLE
Resolve issue with + sign beeing escaped in $FASTCGI_REQUEST_URI

### DIFF
--- a/roles/cs.nginx-magento/templates/magento_vhost.conf.j2
+++ b/roles/cs.nginx-magento/templates/magento_vhost.conf.j2
@@ -66,18 +66,24 @@ server {
 {% if path_config.path != "/" %}
     }
 
+    # XXX: There is undocumented nginx quirk that escapes strings coming from regex anonymous groups (eg $1)
+    # and this causes some+string to be set as some%2Bstring
+    # This behavior does not manifest when we use named groups in expression
+    # This is why there is (?<rest>.*) used to extract values from url
+    # Note that is issue not appears in rewrite rules, therefore in we can keep anonymous groups there
+
     if ( $request_uri ~ ^{{ path_config.path }}$ ) {
         set $FASTCGI_REQUEST_URI /;
     }
     rewrite ^{{ path_config.path }}$ / last;
 
-    if ( $request_uri ~ ^{{ path_config.path }}/(.*)$ ) {
-        set $FASTCGI_REQUEST_URI /$1;
+    if ( $request_uri ~ ^{{ path_config.path }}/(?<rest>.*)$ ) {
+        set $FASTCGI_REQUEST_URI /$rest;
     }
     rewrite ^{{ path_config.path }}/(.*)$ /$1 last;
 
-    if ( $request_uri ~ ^{{ path_config.path }}\?(.*)$ ) {
-        set $FASTCGI_REQUEST_URI /?$1;
+    if ( $request_uri ~ ^{{ path_config.path }}\?(?<rest>.*)$ ) {
+        set $FASTCGI_REQUEST_URI /?$rest;
     }
     rewrite ^{{ path_config.path }}\?(.*)$ /?$1 last;
 {% endif %}


### PR DESCRIPTION
nginx handless differently anonymous regex groups and named capture groups

named variables create variables with name of group
but anonymous groups are handled in special `r->captures` and `r->captures_data` structure,
those are escaped by `ngx_escape_uri` only when their content is copied with `ngx_http_script_copy_capture_code` or`ngx_http_script_copy_capture_len_code`
and this is happening when we use `set` operator
If we use this value without using causing this copy we will have unescaped version (eg. by doing `add_header x-debug $1`)

Because we need to set our url to variable to be able to pass it later to fastcgi, we have to use named capture groups