### PR TITLE
Rotate magento logs in subdirectories

### DIFF
--- a/roles/cs.magento-configure/templates/magento_logrotate.conf.j2
+++ b/roles/cs.magento-configure/templates/magento_logrotate.conf.j2
@@ -1,4 +1,4 @@
-{{ magento_live_release_dir }}/var/log/*.log {
+{{ magento_live_release_dir }}/var/log/*.log {{ magento_live_release_dir }}/var/log/*/*.log {
     size 20M
     rotate 2
     create 0664 {{ magento_user }} {{ magento_group }}


### PR DESCRIPTION
External extensions create log files in subdirectories inside var/log files.
Eg. magento_dir/var/log/subdir/file.log