### PR TITLE
Add support for list in mageops_extra_tasks_*_node

### DIFF
--- a/site.step-15-varnish.yml
+++ b/site.step-15-varnish.yml
@@ -94,7 +94,15 @@
     - role: cs.pkg-mgr-cleanup
 
   tasks:
-    - include_tasks: "{{ mageops_extra_tasks_varnish_node }}"
+    - set_fact:
+        mageops_extra_tasks_varnish_node: [
+          "{{ mageops_extra_tasks_varnish_node }}"
+        ]
+      when: |
+        mageops_extra_tasks_varnish_node is defined
+        and mageops_extra_tasks_varnish_node is string
+    - include_tasks: "{{ item }}"
+      loop: "{{ mageops_extra_tasks_varnish_node }}"
       when: mageops_extra_tasks_varnish_node is defined
 
   vars:

--- a/site.step-20-persistent.yml
+++ b/site.step-20-persistent.yml
@@ -93,7 +93,15 @@
     - role: cs.pkg-mgr-cleanup
 
   tasks:
-    - include_tasks: "{{ mageops_extra_tasks_persistent_node }}"
+    - set_fact:
+        mageops_extra_tasks_persistent_node: [
+          "{{ mageops_extra_tasks_persistent_node }}"
+        ]
+      when: |
+        mageops_extra_tasks_persistent_node is defined
+        and mageops_extra_tasks_persistent_node is string
+    - include_tasks: "{{ item }}"
+      loop: "{{ mageops_extra_tasks_persistent_node }}"
       when: mageops_extra_tasks_persistent_node is defined
 
   vars:

--- a/site.step-40-app-node.yml
+++ b/site.step-40-app-node.yml
@@ -164,7 +164,15 @@
       when: mageops_monitoring_enabled
 
   tasks:
-    - include_tasks: "{{ mageops_extra_tasks_app_node }}"
+    - set_fact:
+        mageops_extra_tasks_app_node: [
+          "{{ mageops_extra_tasks_app_node }}"
+        ]
+      when: |
+        mageops_extra_tasks_app_node is defined
+        and mageops_extra_tasks_app_node is string
+    - include_tasks: "{{ item }}"
+      loop: "{{ mageops_extra_tasks_app_node }}"
       when: mageops_extra_tasks_app_node is defined
 
   vars:


### PR DESCRIPTION
It keeps support for string content but allows also it contain list when multiple tasks need to be added