### PR TITLE
Add option to enable weekly php-fpm restart

### DIFF
--- a/roles/cs.php-fpm/defaults/main.yml
+++ b/roles/cs.php-fpm/defaults/main.yml
@@ -1,5 +1,5 @@
 # --- Base configuration ---
-  
+
 php_fpm_daemon_conf_file_path: "/etc/php-fpm.conf"
 php_fpm_pid_file_path: "{{ php_fpm_run_dir_path }}/php-fpm.pid"
 php_fpm_pool_conf_dir_path: "/etc/php-fpm.d"
@@ -26,6 +26,7 @@ php_fpm_pool_ping_response: pong
 php_fpm_pool_conf_file_path: "{{ php_fpm_pool_conf_dir_path }}/{{ php_fpm_pool_name }}.conf"
 php_fpm_pool_fcgi_socket_path: "{{ php_fpm_run_dir_path }}/{{ php_fpm_pool_name }}.sock"
 
+php_fpm_weekly_restart: no
 
 # --- Extra configuration for the special debug pool ---
 

--- a/roles/cs.php-fpm/tasks/001-daemon.yml
+++ b/roles/cs.php-fpm/tasks/001-daemon.yml
@@ -37,3 +37,12 @@
     loop_var: entry
     label: "{{ entry.path }}"
   register: tmpfiles_config
+
+- name: Create restart php-fpm workaround cron job
+  copy:
+    content: "systemctl reload php-fpm"
+    dest: /etc/cron.weekly/reload-php-fpm
+    owner: root
+    group: root
+    mode: u=rwx,g=rx,o=rx
+  when: php_fpm_weekly_restart


### PR DESCRIPTION
This adds `php_fpm_weekly_restart` option that schedules php-fpm reload every week to prevent slow memory leak to accumulate enough to cause OOM issues on app node