### PR TITLE
aws-magento-cron: fix only_cron_node option

### DIFF
--- a/roles/cs.aws-magento-cron/tasks/main.yml
+++ b/roles/cs.aws-magento-cron/tasks/main.yml
@@ -48,7 +48,7 @@
     name: "{{ item.name }}"
     job: |
       {%- if item.only_cron_node -%}
-        mageopscli is_cron_node &&
+        /usr/local/bin/mageopscli is_cron_node &&
       {%- endif -%}
       {%- if item.magento_command -%}
         cd {{ magento_live_release_dir }} && bin/magento {{ item.command }}


### PR DESCRIPTION
In crons context not all paths are used
and /usr/local/bin in not included
this caused mageopscli to not be found and condition always worked as it is not running on cron node