### PR TITLE
remove aws tags app

### DIFF
--- a/roles/cs.aws-node-ami-builder/tasks/main.yml
+++ b/roles/cs.aws-node-ami-builder/tasks/main.yml
@@ -17,8 +17,6 @@
     instance_tags: >-
       {{
           aws_tags_default | combine(
-            aws_tags_role_app,
-            aws_tags_node_app,
             builder_instance_tags,
             builder_instance_name_tags
           )
@@ -47,9 +45,9 @@
   vars:
     aws_ebs_volume_modify_ids: >-
       {{ ( builder_ec2.instances + builder_ec2.tagged_instances )
-          | map(attribute='block_device_mapping') 
-          | map('dict2items') 
-          | flatten 
+          | map(attribute='block_device_mapping')
+          | map('dict2items')
+          | flatten
           | map(attribute='value')
           | map(attribute='volume_id')
           | list

--- a/site.step-30-builder.yml
+++ b/site.step-30-builder.yml
@@ -7,7 +7,6 @@
       node_state_instance_tags: >-
         {{
             aws_tags_base | combine(
-                aws_tags_role_app,
                 aws_tags_role_app_builder
             )
         }}

--- a/site.step-50-ami.yml
+++ b/site.step-50-ami.yml
@@ -19,7 +19,6 @@
       node_state_instance_tags: >-
         {{
             aws_tags_base | combine(
-                aws_tags_role_app,
                 aws_tags_role_app_builder
             )
         }}


### PR DESCRIPTION
    Builder node used all tags that was also present on app node.
    Varnish app node discovery does also rely on those tags.
    This caused builder node to be included as varnish backend.
    
    Builder node does not require those tags, because app node
    gets them later from ASG, so they can be safely removed.