### PR TITLE
Fix nginx cleanup

### DIFF
--- a/roles/cs.nginx/tasks/000-facts.yml
+++ b/roles/cs.nginx/tasks/000-facts.yml
@@ -4,3 +4,4 @@
 - name: Set list of provisioned nginx conf.d files
   set_fact:
     nginx_config_cleanup_provisioned_files: []
+  when: nginx_config_cleanup_provisioned_files is not defined

--- a/site.step-40-app-node.yml
+++ b/site.step-40-app-node.yml
@@ -88,9 +88,9 @@
       supervisor_service_autostart: no
       supervisor_service_initial_state: stopped
 
-    - role: cs.nginx-url-blacklist
-
     - role: cs.nginx
+
+    - role: cs.nginx-url-blacklist
 
     - role: cs.nginx-magento
       nginx_secure_cron_user: "{{ magento_cron_user }}"


### PR DESCRIPTION
Nginx cleanup registers list of required nginx files
  when cs.nginx role is started
  later all other roles add to that list when they need to extends
  nginx configuration.
  But in case cs.nginx role is executed more than once
  that list is reinitialized and anything that was registered in\
  meantime will be removed

This commit resolved both issues
  First we only initialize `nginx_config_cleanup_provisioned_files`
  only when it doesn't yet exists
  and second we move explicit cs.nginx role before any role
  that have it as dependency, so it's not provisioned twice