### PR TITLE
Disable Block Public Access for media bucket

### DIFF
--- a/roles/cs.aws-s3/tasks/main.yml
+++ b/roles/cs.aws-s3/tasks/main.yml
@@ -9,6 +9,10 @@
     s3_bucket_tags:
       Name: "{{ aws_s3_media_bucket }}"
 
+- name: Disable Public Access Block for Media bucket
+  when: aws_s3_media_bucket_create
+  shell: 'aws s3api delete-public-access-block --bucket "{{ aws_s3_media_bucket }}" --region "{{ aws_region }}"'
+
 - name: Create S3 Secret bucket
   s3_bucket:
     state: present


### PR DESCRIPTION
Aws is introducing new policy that will disable all public access
  to newly created buckets starting form april 2023
  To disable that policy we need to make explicit api call
Another introduced policy will disable object based ACL and force
  using bucket level acl, but this change should not affect us
  and do not require any mitigation