### PR TITLE
Limit access to /WARMUP endpoint

### DIFF
--- a/roles/cs.nginx-magento/templates/magento_server_body.conf.j2
+++ b/roles/cs.nginx-magento/templates/magento_server_body.conf.j2
@@ -22,6 +22,9 @@ location = /WARMUP {
     # If the probe launches magento with no cache it will start
     # warming up by itself causing overload, timeouts and the file
     # generation to fail. In effect the whole env may be down.
+    limit_except HEAD {
+        deny all;
+    }
     try_files $uri =404;
 }
 


### PR DESCRIPTION
This endpoint is required by varnish to make sure
that node already finished generating js/css files before we allow normal parallel traffic
But varnish only uses HEAD requests therefore
we can limit usage of this endpoint