### PR TITLE
Add support for mysql8

### DIFF
--- a/roles/cs.mysql/tasks/flavor/mysql.yml
+++ b/roles/cs.mysql/tasks/flavor/mysql.yml
@@ -17,8 +17,8 @@
     mysql_root_password_update: yes
     mysql_daemon: mysqld
     mysql_packages:
-      - mysql-server
-      - mysql-client
+      - mysql-community-server
+      - mysql-community-client
     mysql_syslog_tag: mysqld
     mysql_pid_file: /var/run/mysqld/mysqld.pid
     mysql_socket: /var/lib/mysql/mysql.sock
@@ -26,3 +26,4 @@
     mysql_log_error: /var/log/mysqld.err
     mysql_slow_query_log_enabled: yes
     mysql_slow_query_time: 1
+    mysql_log: ""

--- a/roles/cs.repo-mysql/defaults/main.yml
+++ b/roles/cs.repo-mysql/defaults/main.yml
@@ -1,16 +1,13 @@
-repo_mysql_package_name: mysql57-community-release
+repo_mysql_package_name: mysql-community-release
 repo_mysql_name_prefix: mysql
 repo_mysql_variants:
   - -connectors-community
   - -tools-community
   - -tools-preview
-  - 55-community
-  - 56-community
   - 57-community
   - 80-community
 
 repo_mysql_variants_enabled:
   - -connectors-community
   - -tools-community
-  - 57-community
-
+  - 80-community


### PR DESCRIPTION
Existing mysql support didn't work correstly
with mysql 8.0
Those changes with updated rpm package add possibility to provision mysql 8.0 server locally