### PR TITLE
Add endpoint parameter to s3fs

### DIFF
--- a/roles/cs.s3-mount/defaults/main.yml
+++ b/roles/cs.s3-mount/defaults/main.yml
@@ -21,6 +21,7 @@ s3fs_options_s3fs:
     - "connect_timeout=900"
     - "iam_role={{ s3fs_iam_role }}"
     - "ensure_diskfree={{ s3fs_ensure_diskfree_mb }}"
+    - "endpoint={{ aws_region }}"
 
 s3fs_options_goofys:
     - "--uid={{ s3fs_owner_uid }}"


### PR DESCRIPTION
s3fs started complaining for missing of this parameter This also causes it to crash, therefore it is now required