### PR TITLE
Allow dynamic setting of new_relic license

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -2024,5 +2024,4 @@ aws_pio_ebs_volume_size: "{{ aws_app_node_ebs_volume_size }}"
 # ----- New Relic -----
 # ---------------------
 new_relic_app_name: "{{ mageops_app_name }}"
-mageops_new_relic_enabled: no
-# new_relic_license need to be set up
+mageops_new_relic_enabled: yes

--- a/roles/cs.new-relic/defaults/main.yml
+++ b/roles/cs.new-relic/defaults/main.yml
@@ -1,7 +1,7 @@
 new_relic_repo_url: http://yum.newrelic.com/pub/newrelic/el5/x86_64/newrelic-repo-5-3.noarch.rpm
 new_relic_packages:
   - newrelic-php5
-# new_relic_license:
+new_relic_license:
 new_relic_app_name: "New relic app name"
 new_relic_collector_enabled: yes
 new_relic_ignore_user_exception_handler: no
@@ -15,7 +15,7 @@ new_relic_stact_trace_threshold: "3s"
 new_relic_explain_enabled: yes
 new_relic_explain_threshold: "500ms"
 new_relic_framework: magento2
-new_relic_enabled: yes
+new_relic_enabled: "{{ new_relic_license != '' }}"
 
 new_relic_cron_enabled: no
 new_relic_cron_start: "0 7 * * *" # From 7:00

--- a/roles/cs.new-relic/files/newrelic_feature.bash
+++ b/roles/cs.new-relic/files/newrelic_feature.bash
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 feature__flag_name="newrelic_apm"
+feature__license_key="newrelic_license_key"
 
 feature::apply() {
     local expected
@@ -9,9 +10,15 @@ feature::apply() {
     expected="$(feature::expected_value)"
     expected="$(feature::normalize_expected "$expected")"
     current="$(feature::current_value)"
+    current_license="$(feature::current_license_value)"
+    expected_license="$(feature::expected_license_value)"
 
-    if [ "$expected" != "$current" ];then
-        feature::update "$expected"
+    if [ -z "$expected_license" ];then
+        # We cannot enable the feature without a license key
+        expected="false"
+    fi
+    if [ "$expected" != "$current" ] || [ "$expected_license" != "$current_license" ];then
+        feature::update "$expected" "$expected_license"
     fi
 }
 
@@ -34,6 +41,10 @@ feature::expected_value() {
     features::read_feature_flag "$feature__flag_name" "false"
 }
 
+feature::expected_license_value() {
+    features::read_feature_flag "$feature__license_key" ""
+}
+
 feature::current_value() {
     local current
 
@@ -46,12 +57,21 @@ feature::current_value() {
     echo "$current"
 }
 
+feature::current_license_value() {
+    local current
+
+    current="$(grep '^newrelic.license' /etc/php.d/newrelic.ini | sed 's/.*=\s*"\(.*\)"\s*$/\1/')"
+
+    echo "$current"
+}
+
 feature::update() {
     local value=$1
-    local config
+    local license=$2
 
     echo "Setting newrelic apm to $value"
     sed -i -e "s/newrelic.enabled[[:space:]]=[[:space:]].*/newrelic.enabled = ${value}/" /etc/php.d/newrelic.ini
+    sed -i -e "s/newrelic.license[[:space:]]=[[:space:]].*/newrelic.license = \"${license}\"/" /etc/php.d/newrelic.ini
     echo "Reloading php-fpm"
     systemctl reload php-fpm
 }

--- a/roles/cs.new-relic/tasks/main.yml
+++ b/roles/cs.new-relic/tasks/main.yml
@@ -32,6 +32,10 @@
   shell: "mageopscli set_feature_flag newrelic_apm {{ new_relic_enabled | ternary('true', 'false') }}"
   when: aws_use
 
+- name: Set license key feature flag
+  shell: "mageopscli set_feature_flag newrelic_license_key \"{{ new_relic_license }}\""
+  when: aws_use
+
 - name: Setup cron
   template:
     src: cron.j2


### PR DESCRIPTION
With this change set, new relic is always installed on app nodes but is disabled if license key is missing
APM can be enabled at runtime by setting new license key in feature flag:
```bash
mageopscli set_feature_flag newrelic_license_key 123asd
```

and enabling apm
```bash
mageopscli set_feature_flag newrelic_apm yes
```