### PR TITLE
Fix ban exclusive traffic when x-forward-for include more IPs

### DIFF
--- a/roles/cs.cloudflare/defaults/main.yml
+++ b/roles/cs.cloudflare/defaults/main.yml
@@ -5,6 +5,8 @@ cloudflare_exclusive_traffic: yes
 # configuration file paths
 cloudflare_nginx_config_filename: 000-cloudflare.conf
 cloudflare_nginx_config: "{{ nginx_confd_dir }}/{{ cloudflare_nginx_config_filename }}"
+cloudflare_nginx_map_filename: 001-map_proper_x_forward_for.conf
+cloudflare_nginx_map: "{{ nginx_confd_dir }}/{{ cloudflare_nginx_map_filename }}"
 cloudflare_update_script: "/etc/cron.daily/update_nginx_config.sh"
-cloudflare_nginx_block_non_cf_traffic_config_directory: "{{ nginx_confd_dir }}/server.d/default"
+cloudflare_nginx_block_non_cf_traffic_config_directory: "{{ nginx_etc_dir }}/server.d/defaults"
 cloudflare_nginx_block_non_cf_traffic_config: "{{ cloudflare_nginx_block_non_cf_traffic_config_directory }}/ban-non-cf.conf"

--- a/roles/cs.cloudflare/tasks/disable.yml
+++ b/roles/cs.cloudflare/tasks/disable.yml
@@ -6,6 +6,10 @@
   file:
     path: "{{ cloudflare_nginx_config }}"
     state: absent
+- name: Remove map file
+  file:
+    path: "{{ cloudflare_nginx_map }}"
+    state: absent
 - name: Remove CF exclusive traffic config
   file:
     path: "{{ cloudflare_nginx_block_non_cf_traffic_config }}"

--- a/roles/cs.cloudflare/tasks/enable.yml
+++ b/roles/cs.cloudflare/tasks/enable.yml
@@ -19,6 +19,12 @@
     src: ban-non-cf-traffic.conf
     dest: "{{ cloudflare_nginx_block_non_cf_traffic_config }}"
 
+- name: Map x-forward-for to return only last IP
+  when: cloudflare_exclusive_traffic
+  template:
+    src: map_proper_x_forward_for.conf
+    dest: "{{ cloudflare_nginx_map }}"
+
 - name: Register provisioned nginx config files
   set_fact:
     nginx_config_cleanup_provisioned_files: "{{ nginx_config_cleanup_provisioned_files + provisioned_configs }}"
@@ -33,3 +39,4 @@
   vars:
     provisioned_configs:
       - "{{ cloudflare_nginx_block_non_cf_traffic_config }}"
+      - "{{ cloudflare_nginx_map }}"

--- a/roles/cs.cloudflare/templates/ban-non-cf-traffic.conf
+++ b/roles/cs.cloudflare/templates/ban-non-cf-traffic.conf
@@ -3,6 +3,6 @@ if ($http_cf_connecting_ip = "") {
 }
 
 # If those do not match it means that we didn't accepted it as valid forward
-if ($remote_addr != $http_x_forwarded_for) {
+if ($remote_addr != $last_http_x_forwarded_for) {
         return 403;
 }

--- a/roles/cs.cloudflare/templates/map_proper_x_forward_for.conf
+++ b/roles/cs.cloudflare/templates/map_proper_x_forward_for.conf
@@ -1,0 +1,4 @@
+map $http_x_forwarded_for $last_http_x_forwarded_for {
+        default $http_x_forwarded_for;
+        "~*,\s*(?<last_ip>[^,]+)$" $last_ip;
+    }


### PR DESCRIPTION
In the current develop branch if x-forward-for has more than 1 IP access is blocked. In case of f.ex. Zendesk add more IP to the x-forward-for list which causes unexpected block access.