### PR TITLE
QA/Testing Team request to skip varnish cache - rocky

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -812,6 +812,36 @@ mageops_debug_token_http_header: "{{ mageops_debug_http_header_prefix }}-Token"
 # forward it from every app node at once or guess to which one the request goes.
 mageops_xdebug_proxy_remote_connection_to_loadbalancer: "{{ varnish_as_loadbalancer }}"
 
+# ---------------------------------------------
+# --------  MageOps Cache Bypass  --------
+# ---------------------------------------------
+# NOTE: All header/param/cookie names must use only alphanumeric characters
+# and underscores only! Any other character may and probably will break stuff.
+# This is due to intricacies of nginx / varnish configuration languages,
+# various HTTP considerations, better be safe than sorry!
+
+# Secret, unique string used for authorizing debugging sessions
+# and for accessing other debug functionality
+#
+# WARNING! Must be safe to be used as a HTTP request query argument value
+# so stick to alphanumeric characters only!
+
+mageops_bypass_token: "{{ mageops_secret_token }}"
+
+# Name of the HTTP requests's query parameter that triggers bypass mode
+mageops_bypass_token_query_param: "{{ mageops_query_param_prefix }}_bypass_token"
+
+# Name of the HTTP Cookie that triggers bypass mode
+mageops_bypass_token_request_cookie: "{{ mageops_cookie_prefix }}BypassToken"
+
+# Prefix for all HTTP headers related to bypass information or behavior
+# - This is nice to have in a variable in case we need to do special processing
+#   of all requests containing any of these headers.
+mageops_bypass_http_header_prefix: "{{ mageops_http_header_prefix }}-Bypass"
+
+# Name of the header that enables bypass mode (cache passthrough)
+mageops_bypass_token_http_header: "{{ mageops_bypass_http_header_prefix }}-Token"
+
 # ------------------------------------------
 # --------  SSH Key Authorizations  --------
 # ------------------------------------------
@@ -1807,7 +1837,7 @@ mageops_packages_base:
   - jq
   - curl
   - wget
-  # This must be installed before new relic and blackfire
+ # This must be installed before new relic and blackfire
   # Otherwise it will corrupt /etc/init.d directory and cause chkconfig fail to install
   - initscripts
 

--- a/roles/cs.varnish/defaults/main.yml
+++ b/roles/cs.varnish/defaults/main.yml
@@ -63,7 +63,6 @@ varnish_workspace_client: 64k
 varnish_workspace_thread: 4k
 
 # As of varnish 6.0 the default is 48k and lower values cause segfault with our VCL
-# 128k is minimum for aarch64
 varnish_thread_pool_stack: 128k
 
 # Max. number of thread pools that should be at most the number of vCPUs
@@ -168,6 +167,14 @@ varnish_debug_request_query_param_name: ___varnish_debug_token___
 varnish_debug_request_cookie_name: ___varnish_debug_token___
 varnish_debug_request_header_name: X-Varnish-Debug-Token
 varnish_debug_request_info_header_name: X-Varnish-Debug-Request-Info
+
+varnish_bypass_request_token: ~
+varnish_bypass_request_query_param_name: ___varnish_bypass_token___
+varnish_bypass_request_cookie_name: ___varnish_bypass_token___
+varnish_bypass_request_header_name: X-Varnish-bypass-Token
+varnish_bypass_request_info_header_name: X-Varnish-bypass-Request-Info
+
+
 varnish_media_cors_enabled: yes
 varnish_media_cors_max_age: 2678400
 

--- a/roles/cs.varnish/templates/vcl/subroutines/deliver.vcl.j2
+++ b/roles/cs.varnish/templates/vcl/subroutines/deliver.vcl.j2
@@ -33,6 +33,13 @@ if (req.http.{{ varnish_debug_request_info_header_name }}) {
         req.http.{{ varnish_debug_request_info_header_name }} + "; Backend-Response-Delivered";
 }
 
+if (req.http.{{ varnish_bypass_request_info_header_name }}) {
+    set resp.http.{{ varnish_bypass_request_info_header_name }} =
+        req.http.{{ varnish_bypass_request_info_header_name }} + "; Backend-Response-Delivered";
+    set resp.http.Set-Cookie = "{{ varnish_bypass_request_cookie_name}} = {{ varnish_bypass_request_token }}; Secure";
+    set resp.http.Cache-Control = "no-cache";
+}
+
 if (resp.status == 502 || resp.status == 504) {
     return(synth(resp.status));
 }

--- a/roles/cs.varnish/templates/vcl/subroutines/recv.vcl.j2
+++ b/roles/cs.varnish/templates/vcl/subroutines/recv.vcl.j2
@@ -142,6 +142,29 @@ if (
 }
 {% endif %}
 
+{% if varnish_bypass_request_token | default(false, true) %}
+#Bypass conditions
+{% set varnish_bypass_request_token_query_param_pattern =
+    ( varnish_bypass_request_query_param_name | regex_escape )
+    ~ '=' ~ ( varnish_bypass_request_token | regex_escape )
+%}
+
+{% set varnish_bypass_request_token_cookie_pattern =
+    ( varnish_bypass_request_cookie_name | regex_escape )
+    ~ '=' ~ ( varnish_bypass_request_token | regex_escape )
+%}
+
+if (
+    req.url ~ "{{ varnish_bypass_request_token_query_param_pattern }}"
+    || req.http.{{ varnish_bypass_request_header_name }} == "{{ varnish_bypass_request_token }}"
+    || req.http.Cookie ~ "(^|;\s*){{ varnish_bypass_request_token_cookie_pattern }}(;|$)"
+) {
+    set req.http.{{ varnish_bypass_request_info_header_name }} = "Token-Verified; Cache-Bypassed; Xid=" + req.xid + "";
+
+    return (pass);
+}
+{% endif %}
+
 if (req.http.X-Blackfire-Query) {
     if (req.esi_level > 0) {
         unset req.http.X-Blackfire-Query;

--- a/site.step-15-varnish.yml
+++ b/site.step-15-varnish.yml
@@ -72,6 +72,10 @@
       varnish_debug_request_query_param_name: "{{ mageops_debug_token_query_param }}"
       varnish_debug_request_cookie_name: "{{ mageops_debug_token_request_cookie }}"
       varnish_debug_request_header_name: "{{ mageops_debug_token_http_header }}"
+      varnish_bypass_request_token: "{{ mageops_bypass_token }}"
+      varnish_bypass_request_query_param_name: "{{ mageops_bypass_token_query_param }}"
+      varnish_bypass_request_cookie_name: "{{ mageops_bypass_token_request_cookie }}"
+      varnish_bypass_request_header_name: "{{ mageops_bypass_token_http_header }}"
       varnish_magento_vary_sign: "{{ mageops_magento_vary_sign_enabled }}"
       varnish_magento_vary_secret: "{{ mageops_magento_vary_sign_secret }}"
     - role: cs.varnish-manager

--- a/site.step-40-app-node.yml
+++ b/site.step-40-app-node.yml
@@ -126,6 +126,10 @@
       varnish_debug_request_query_param_name: "{{ mageops_debug_token_query_param }}"
       varnish_debug_request_cookie_name: "{{ mageops_debug_token_request_cookie }}"
       varnish_debug_request_header_name: "{{ mageops_debug_token_http_header }}"
+      varnish_bypass_request_token: "{{ mageops_bypass_token }}"
+      varnish_bypass_request_query_param_name: "{{ mageops_bypass_token_query_param }}"
+      varnish_bypass_request_cookie_name: "{{ mageops_bypass_token_request_cookie }}"
+      varnish_bypass_request_header_name: "{{ mageops_bypass_token_http_header }}"
       when: not varnish_standalone
 
     - role: cs.blackfire


### PR DESCRIPTION
For this purpose you can add ?__mgo_bypass_token=token to URL. This action set MageOpsBypassToken cookie and works utill this cookie will be deleted. When the cookie is set Varnish will deliver content without using cache.