### PR TITLE
Lock geerlingguy.ntp module to version 2.4.0

### DIFF
--- a/requirements-galaxy.yml
+++ b/requirements-galaxy.yml
@@ -1,7 +1,8 @@
+roles:
 - src: geerlingguy.mysql
 - src: geerlingguy.composer
 - src: geerlingguy.ntp
-
+  version: 2.4.0
 - src: pinkeen.postfix
   version: v1.1
 
@@ -13,4 +14,3 @@
 
 - src: zauberpony.mysql-query
   version: v0.6.1
-


### PR DESCRIPTION
Lock geerlingguy.ntp module to version 2.4.0. Newest version is not working with RedHat/CentOS/Rocky