### PR TITLE
Move all headers from vhost definition into location.

### DIFF
--- a/roles/cs.nginx-https-termination/templates/nginx.vhost.conf
+++ b/roles/cs.nginx-https-termination/templates/nginx.vhost.conf
@@ -22,10 +22,6 @@
     ssl_session_timeout 1d;
     ssl_session_cache shared:mageops:20m;
     ssl_session_tickets off;
-    add_header Strict-Transport-Security "max-age={{ https_termination_sts_max_age }}" always;
-    {% if mageops_prevent_mime_sniffing -%}
-        add_header x-content-type-options "nosniff" always;
-    {%- endif %}
 
     ssl_certificate {{ vhost.crt_live_fullchain_path }};
     ssl_certificate_key {{ vhost.crt_live_key_path }};
@@ -94,6 +90,12 @@ server {
 {% else %}
     location / {
 {% endif %}
+
+    add_header Strict-Transport-Security "max-age={{ https_termination_sts_max_age }}" always;
+{% if mageops_prevent_mime_sniffing %}
+    add_header x-content-type-options "nosniff" always;
+{%- endif %}
+
 {% if https_termination_nginx_server_cookie_rewrite_config | length > 0 %}
     if ($request_uri !~* ^/(media|static)) {
     {% for cookie_js_name, cookie_config in https_termination_nginx_server_cookie_rewrite_config.items() %}


### PR DESCRIPTION
nginx does not allow to have `add_header` directive at server and location at the same time. This causes that server scoped headers are overwritten by location ones.