### PR TITLE
 Bump memory reserved for system on varnish node

### DIFF
--- a/roles/cs.varnish/defaults/main.yml
+++ b/roles/cs.varnish/defaults/main.yml
@@ -38,7 +38,7 @@ varnish_storage_mem_rel: 0.7
 # The minimum amount of system memory that has to be reserved for other
 # services. This variable has effect only if the memory left after subtracting
 # the `varnish_sys_mem_rel` calculation is smaller than this value.
-varnish_sys_mem_reserved: 128M
+varnish_sys_mem_reserved: 512M
 
 # Since we don't write logs anywhere the default of 80M seems to be an overkill
 # https://varnish-cache.org/docs/6.0/reference/varnishd.html#vsl-space


### PR DESCRIPTION
Rocky linux have higher memory requirements and we nowadays often have more services running on the same node (like pio-director).