### PR TITLE
Change supervisord systemd service to autorestart

### DIFF
--- a/roles/cs.supervisor/tasks/main.yml
+++ b/roles/cs.supervisor/tasks/main.yml
@@ -11,11 +11,26 @@
   when: supervisor_programs | length > 0
   notify: Reload supervisord
 
-- name: Force a restart if configuration has changed
-  meta: flush_handlers
+- name: Ensure Supervisor systemd config override directory exists
+  file:
+    path: /etc/systemd/system/supervisord.service.d/
+    state: directory
 
-- name: Enable and start supervisord
-  service:
+- name: Create systemd service file for supervisord
+  template:
+    src: supervisord.overrides.conf
+    dest: /etc/systemd/system/supervisord.service.d/mageops.conf
+
+- name: Reload systemd
+  command: systemctl daemon-reload
+
+- name: Enable and start the service
+  systemd:
     name: supervisord
     enabled: "{{ supervisor_service_autostart }}"
     state: "{{ supervisor_service_initial_state }}"
+
+- name: Force a restart if configuration has changed
+  meta: flush_handlers
+
+

--- a/roles/cs.supervisor/tasks/main.yml
+++ b/roles/cs.supervisor/tasks/main.yml
@@ -24,7 +24,7 @@
 - name: Reload systemd
   command: systemctl daemon-reload
 
-- name: Enable and start the service
+- name: Enable and start supervisord
   systemd:
     name: supervisord
     enabled: "{{ supervisor_service_autostart }}"

--- a/roles/cs.supervisor/templates/supervisord.overrides.conf
+++ b/roles/cs.supervisor/templates/supervisord.overrides.conf
@@ -1,0 +1,3 @@
+[Service]
+Restart=always
+RestartSec=5


### PR DESCRIPTION
Change supervisord systemd service to autorestart. Currently when supervisord died f.ex. due to OOM manual action is needed.