### PR TITLE
Set priority nginx repo

### DIFF
--- a/roles/cs.repo-nginx/templates/nginx.repo
+++ b/roles/cs.repo-nginx/templates/nginx.repo
@@ -3,6 +3,7 @@ name=nginx stable repo
 baseurl=http://nginx.org/packages/centos/$releasever/$basearch/
 gpgcheck=1
 enabled=1
+priority=1
 gpgkey=https://nginx.org/keys/nginx_signing.key
 module_hotfixes=true
 


### PR DESCRIPTION
Set priority to repo nginx to install nginx from nginx repo instead of System.