### PR TITLE
Use patched amazon.aws

### DIFF
--- a/requirements-galaxy.yml
+++ b/requirements-galaxy.yml
@@ -12,8 +12,10 @@ roles:
 collections:
 - name: community.aws
   version: 9.0.0
-- name: amazon.aws
-  version: 9.1.1
+# Workaround until https://github.com/ansible-collections/amazon.aws/pull/2542 is merged
+- name: https://github.com/Szpadel/amazon.aws
+  type: git
+  version: workaround
 - name: community.mysql
 - name: ansible.utils
   version: 2.10.3


### PR DESCRIPTION
woraround until https://github.com/ansible-collections/amazon.aws/pull/2542 is merged