### PR TITLE
Add ipv6 to varnish acl

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -911,8 +911,11 @@ mageops_http_pipeline_request_timeout_override: "{{ mageops_http_pipeline_reques
 
 mageops_trusted_cidr_blocks_global: []
 mageops_trusted_cidr_blocks_extra: []
+mageops_trusted_cidr_ipv6_blocks_global: []
+mageops_trusted_cidr_ipv6_blocks_extra: []
 
 mageops_trusted_cidr_blocks: "{{ mageops_trusted_cidr_blocks_global + mageops_trusted_cidr_blocks_extra }}"
+mageops_trusted_cidr_ipv6_blocks: "{{ mageops_trusted_cidr_ipv6_blocks_global + mageops_trusted_cidr_ipv6_blocks_extra }}"
 
 
 # -----------------------------------------------------

--- a/site.step-15-varnish.yml
+++ b/site.step-15-varnish.yml
@@ -65,7 +65,7 @@
       varnish_secure_site: "{{ mageops_secure_site }}"
       varnish_secure_site_user: "{{ mageops_secure_site_user }}"
       varnish_secure_site_password: "{{ mageops_secure_site_password }}"
-      varnish_trusted_ips: "{{ mageops_trusted_cidr_blocks }}"
+      varnish_trusted_ips: "{{ mageops_trusted_cidr_blocks + mageops_trusted_cidr_ipv6_blocks }}"
       varnish_purge_trusted_ips: "{{ (aws_vpc_subnet_prefix is defined)|ternary([aws_vpc_subnet_prefix ~ '.0.0/16'], []) }}"
       varnish_purge_logging: "{{ mageops_varnish_purge_logging }}"
       varnish_debug_request_token: "{{ mageops_debug_token }}"


### PR DESCRIPTION
In case of use cloudflare Varnish see IPv6 address as source IP. This fix add mageops_trusted_cidr_ipv6_blocks_global and mageops_trusted_cidr_ipv6_blocks_extra for adding IPv6 addresses to varnish trusted list.