### PR TITLE
Add separate list for basic auth

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -725,7 +725,9 @@ mageops_varnish_purge_logging: yes
 mageops_varnish_host: 127.0.0.1
 mageops_varnish_port: "{% if mageops_https_termination_enable %}8000{% else %}80{% endif %}"
 mageops_varnish_backend_port: "{% if varnish_is_in_autoscaling_group %}8080{% else %}80{% endif %}"
-
+mageops_varnish_trusted_ips : "{{ mageops_varnish_trusted_ips_global + mageops_varnish_trusted_ips_extra }}"
+mageops_varnish_trusted_ips_global: []
+mageops_varnish_trusted_ips_extra: []
 # The directory where application releases are stored - this is not public directory and not app root!
 mageops_app_web_dir: "{{ nginx_www_dir }}/{{ mageops_app_type }}"
 
@@ -911,12 +913,8 @@ mageops_http_pipeline_request_timeout_override: "{{ mageops_http_pipeline_reques
 
 mageops_trusted_cidr_blocks_global: []
 mageops_trusted_cidr_blocks_extra: []
-mageops_trusted_cidr_ipv6_blocks_global: []
-mageops_trusted_cidr_ipv6_blocks_extra: []
 
 mageops_trusted_cidr_blocks: "{{ mageops_trusted_cidr_blocks_global + mageops_trusted_cidr_blocks_extra }}"
-mageops_trusted_cidr_ipv6_blocks: "{{ mageops_trusted_cidr_ipv6_blocks_global + mageops_trusted_cidr_ipv6_blocks_extra }}"
-
 
 # -----------------------------------------------------
 # --------  App Transactional E-mail Settings  --------

--- a/site.step-15-varnish.yml
+++ b/site.step-15-varnish.yml
@@ -65,7 +65,7 @@
       varnish_secure_site: "{{ mageops_secure_site }}"
       varnish_secure_site_user: "{{ mageops_secure_site_user }}"
       varnish_secure_site_password: "{{ mageops_secure_site_password }}"
-      varnish_trusted_ips: "{{ mageops_trusted_cidr_blocks + mageops_trusted_cidr_ipv6_blocks }}"
+      varnish_trusted_ips: "{{ mageops_trusted_cidr_blocks + mageops_varnish_trusted_ips }}"
       varnish_purge_trusted_ips: "{{ (aws_vpc_subnet_prefix is defined)|ternary([aws_vpc_subnet_prefix ~ '.0.0/16'], []) }}"
       varnish_purge_logging: "{{ mageops_varnish_purge_logging }}"
       varnish_debug_request_token: "{{ mageops_debug_token }}"


### PR DESCRIPTION
Currently, basic auth is taken from mageops_trusted_cidr_blocks. In some cases, we want to bypass basic auth without access to ssh or like in case of Cloudflare add ipv6 addresses. mageops_varnish_trusted_ips_global and mageops_varnish_trusted_ips_extra allow us to add additional IP to the whitelist. IPs from mageops_trusted_cidr_blocks are still whitelited.