### PR TITLE
Make epel testing optional

### DIFF
--- a/roles/cs.repo-epel/defaults/main.yml
+++ b/roles/cs.repo-epel/defaults/main.yml
@@ -1,3 +1,4 @@
 repo_epel_package_name: epel-release
 repo_epel_name: epel
+repo_epel_testing: yes
 repo_epel_enabled: yes

--- a/roles/cs.repo-epel/tasks/main.yml
+++ b/roles/cs.repo-epel/tasks/main.yml
@@ -7,6 +7,11 @@
 
 - name: Ensure EPEL is enabled
   command: yum-config-manager --enable epel-testing
+  when: repo_epel_testing | bool
+
+- name: Ensure EPEL is disabled
+  command: yum-config-manager --disable epel-testing
+  when: not repo_epel_testing | bool
 
 - name: Ensure crb is enabled
   command: yum-config-manager --enable crb


### PR DESCRIPTION
Currently epel testing is enabled. This PR enable or disable testing repo via variable repo_epel_testing