### PR TITLE
Remove force charset for MySQL

### DIFF
--- a/roles/cs.magento-configure/defaults/main/app-etc.yml
+++ b/roles/cs.magento-configure/defaults/main/app-etc.yml
@@ -45,7 +45,6 @@ magento_app_etc_config:
         password: "{{ mageops_app_mysql_pass }}"
         model: mysql4
         engine: innodb
-        initStatements: "SET NAMES utf8;"
         active: "1"
 
   resource:


### PR DESCRIPTION
Force charset for MySQL is not longer needed and charset works good setup by Magento.