### PR TITLE
Increase max php-fpm workers limit to 8 per cpu

### DIFF
--- a/roles/cs.php-fpm/tasks/main.yml
+++ b/roles/cs.php-fpm/tasks/main.yml
@@ -14,11 +14,19 @@
           ) | int
       }}
 
-    php_fpm_pm_max_children_by_cpu: "{{ ansible_processor_vcpus * 4 | int }}"
+    php_fpm_pm_max_children_by_cpu: "{{ ansible_processor_vcpus * 8 | int }}"
 
 - name: Calculate default workers
   set_fact:
-    php_fpm_pm_max_children_default: "{{ [ [ php_fpm_pm_max_children_by_memory | int, php_fpm_pm_max_children_by_cpu | int ] | min, 4 ] | max }}"
+    # At least 4 workers, but limit by memory and CPU capacity
+    php_fpm_pm_max_children_default: "{{
+      [
+        [
+          php_fpm_pm_max_children_by_memory | int,
+          php_fpm_pm_max_children_by_cpu | int
+        ] | min,
+        4
+      ] | max }}"
 
 - name: Calculate workers
   set_fact:


### PR DESCRIPTION
This allows to increase request capacity for db/session bound requests and provide more buffer until autoscaling kicks in