### PR TITLE
feat: DEVOPS-578 adjust redis configuration for magento 2.4

### DIFF
--- a/roles/cs.magento-configure/defaults/main/app-etc.yml
+++ b/roles/cs.magento-configure/defaults/main/app-etc.yml
@@ -129,12 +129,17 @@ magento_app_etc_config_cache_default_redis:
   cache:
     frontend:
       default:
-        backend: Cm_Cache_Backend_Redis
+        backend: "{{ magento_redis_cache_backend_fqcn }}"
         backend_options:
           server: "{{ mageops_redis_host }}"
           database: "0"
           port: "{{ mageops_redis_port }}"
           persistent: "magento_redis_cache_default"
+          preload_keys:
+            - EAV_ENTITY_TYPES
+            - GLOBAL_PLUGIN_LIST
+            - DB_IS_UP_TO_DATE
+            - SYSTEM_DEFAULT
 
 magento_app_etc_config_cache_default_redis_l2:
   cache:
@@ -159,9 +164,38 @@ magento_app_etc_config_cache_default_redis_l2:
             cache_dir: "{{ magento_redis_cache_l2_dir }}"
         frontend_options:
           write_control: false
+      stale_cache_enabled:
+        backend: \Magento\Framework\Cache\Backend\RemoteSynchronizedCache
+        backend_options:
+          remote_backend: "{{ magento_redis_cache_backend_fqcn }}"
+          remote_backend_options:
+            persistent: 0
+            server: "{{ mageops_redis_host }}"
+            database: "0"
+            port: "{{ mageops_redis_port }}"
+            password: ""
+          local_backend: Cm_Cache_Backend_File
+          local_backend_options:
+            cache_dir: "{{ magento_redis_cache_l2_dir }}"
+        frontend_options:
+          write_control: false
     type:
       default:
         frontend: default
+      layout:
+        frontend: stale_cache_enabled
+      block_html:
+        frontend: stale_cache_enabled
+      reflection:
+        frontend: stale_cache_enabled
+      config_integration:
+        frontend: stale_cache_enabled
+      config_integration_api:
+        frontend: stale_cache_enabled
+      full_page:
+        frontend: stale_cache_enabled
+      translate:
+        frontend: stale_cache_enabled
 
 magento_app_etc_config_cache_page_redis:
   cache:

--- a/roles/cs.magento-configure/defaults/main/app-etc.yml
+++ b/roles/cs.magento-configure/defaults/main/app-etc.yml
@@ -177,6 +177,7 @@ magento_app_etc_config_cache_default_redis_l2:
           local_backend: Cm_Cache_Backend_File
           local_backend_options:
             cache_dir: "{{ magento_redis_cache_l2_dir }}"
+          use_stale_cache: true
         frontend_options:
           write_control: false
     type:

--- a/roles/cs.magento-configure/defaults/main/general.yml
+++ b/roles/cs.magento-configure/defaults/main/general.yml
@@ -34,7 +34,7 @@ magento_session_max_redis_concurrency: 15
 # Use legacy cache backend class 'Cm_Cache_Backend_Redis'
 # which is the only one available for Magento < 2.3.5 !
 # See: https://devdocs.magento.com/guides/v2.4/config-guide/redis/redis-pg-cache.html#new-redis-cache-implementation
-magento_redis_cache_backend_legacy: yes
+magento_redis_cache_backend_legacy: no
 magento_redis_cache_backend_fqcn: >-
   {{ magento_redis_cache_backend_legacy
       | ternary(


### PR DESCRIPTION
This improves caching features in Magento.
- Use magento class instead of old legacy class Cm
- Added preloaded keys to the standard configuration
- Extend L2 Cache configuration with stale cache enabled