### PR TITLE
Remove from s3 nonempty as obsolete option

### DIFF
--- a/roles/cs.s3-mount/tasks/002-setup-mounts.yml
+++ b/roles/cs.s3-mount/tasks/002-setup-mounts.yml
@@ -48,7 +48,7 @@
     path: "{{ s3fs_bucket.mountpoint }}"
     src: "{{ s3fs_mount_fuse_binary }}#{{ s3fs_bucket.bucket }}"
     fstype: fuse
-    opts: "_netdev,allow_other,nonempty,auto,{{ s3fs_mount_opts | join(',') }}"
+    opts: "_netdev,allow_other,auto,{{ s3fs_mount_opts | join(',') }}"
     state: mounted
   loop: "{{ s3fs_buckets }}"
   loop_control:


### PR DESCRIPTION
Current deployments failes due to unknown option. This option is enabled by default right now.