### PR TITLE
Add slowlog depth trace option to PHP

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1480,7 +1480,7 @@ php_cli_opcache_file_cache_enable: no
 php_fpm_pm_type: static
 php_fpm_pm_max_children: ""
 php_fpm_pm_max_requests: 100
-mageops_php_fpm_slowlog_trace_depth: 30
+php_fpm_slowlog_trace_depth: 30
 # -----------------------------
 # --------  Blackfire  --------
 # -----------------------------

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1480,7 +1480,7 @@ php_cli_opcache_file_cache_enable: no
 php_fpm_pm_type: static
 php_fpm_pm_max_children: ""
 php_fpm_pm_max_requests: 100
-
+mageops_php_fpm_slowlog_trace_depth: 30
 # -----------------------------
 # --------  Blackfire  --------
 # -----------------------------

--- a/roles/cs.php-fpm/defaults/main.yml
+++ b/roles/cs.php-fpm/defaults/main.yml
@@ -14,6 +14,7 @@ php_fpm_pm_min_spare_servers: 5
 php_fpm_pm_max_spare_servers: 5
 php_fpm_pm_max_requests: 500
 php_fpm_terminate_timeout: 600
+php_fpm_slowlog_trace_depth: 30
 
 # Used for naming files, directories and services
 php_fpm_pool_name: "app"

--- a/roles/cs.php-fpm/templates/php-fpm.pool.conf
+++ b/roles/cs.php-fpm/templates/php-fpm.pool.conf
@@ -26,6 +26,9 @@ ping.response = "{{ php_fpm_pool_ping_response }}"
 
 request_terminate_timeout = {{ php_fpm_terminate_timeout }}
 request_slowlog_timeout = 5
+request_slowlog_trace_depth = {{ php_fpm_slowlog_trace_depth }}
+
+
 slowlog = {{ php_fpm_log_dir_path }}/{{ php_fpm_pool_name }}.slow.log
 
 catch_workers_output = yes

--- a/site.step-40-app-node.yml
+++ b/site.step-40-app-node.yml
@@ -110,7 +110,6 @@
       php_fpm_pool_user: "{{ magento_user }}"
       php_fpm_pool_group: "{{ magento_group }}"
       php_fpm_terminate_timeout: "{{ mageops_http_pipeline_request_timeout_override }}"
-      php_fpm_slowlog_trace_depth: "{{ mageops_php_fpm_slowlog_trace_depth }}"
 
     - role: cs.php-tideways
 

--- a/site.step-40-app-node.yml
+++ b/site.step-40-app-node.yml
@@ -110,6 +110,7 @@
       php_fpm_pool_user: "{{ magento_user }}"
       php_fpm_pool_group: "{{ magento_group }}"
       php_fpm_terminate_timeout: "{{ mageops_http_pipeline_request_timeout_override }}"
+      php_fpm_slowlog_trace_depth: "{{ mageops_php_fpm_slowlog_trace_depth }}"
 
     - role: cs.php-tideways
 


### PR DESCRIPTION
Standard depth trace in PHP (20) is not enough. This PR change standart to 30 and enable to change this parameter by variable mageops_php_fpm_slowlog_trace_depth.