### PR TITLE
Exclude read replica from aws_rds_instances

### DIFF
--- a/roles/cs.aws-rds-facts/tasks/main.yml
+++ b/roles/cs.aws-rds-facts/tasks/main.yml
@@ -13,6 +13,15 @@
   vars:
     rds_instances_tag_filter_query: "[?{% for k, v in aws_rds_facts_mysql_tags.items() -%}tags.{{ k }} == '{{ v }}'{% if not loop.last %} && {% endif %}{% endfor %}]"
 
+- name: Filter out read replica instances
+  set_fact:
+    aws_rds_instances: >-
+      {{
+        aws_rds_instances
+        | rejectattr('read_replica_source_db_instance_identifier', 'defined')
+        | list
+      }}
+
 - name: Warn when more than one instance has been found
   debug:
     msg: |

--- a/roles/cs.aws-rds/defaults/main.yml
+++ b/roles/cs.aws-rds/defaults/main.yml
@@ -15,7 +15,7 @@ aws_rds_security_groups:
 aws_rds_param_group_name: "{{ mageops_app_name }}-{{ aws_rds_param_group_engine | replace('.', '-') }}"
 aws_rds_param_group_desc: "MageOps parameter group"
 aws_rds_db_engine_version: "8.0"
-aws_rds_param_group_engine: "{{ aws_rds_db_engine }}{{ aws_rds_db_engine_version }}"
+aws_rds_param_group_engine: "{{ aws_rds_db_engine }}{{ (aws_rds_db_engine_version | string).split('.')[0:2] | join('.') }}"
 
 # https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PerfInsights.Overview.Engines.html
 aws_rds_performance_insights_unavailable_instances: [ db.t2.micro, db.t2.small, db.t3.micro, db.t3.small, db.t4g.micro, db.t4g.small ]

--- a/roles/cs.aws-rds/tasks/main.yml
+++ b/roles/cs.aws-rds/tasks/main.yml
@@ -44,6 +44,15 @@
     db_instance_identifier: "{{ aws_rds_instance_name }}"
   register: aws_rds_current
 
+- name: Store primary RDS configuration snapshot
+  set_fact:
+    aws_rds_primary_current: "{{ aws_rds_current }}"
+
+- name: Collect read replicas attached to primary RDS instance
+  set_fact:
+    aws_rds_read_replica_instance_identifiers: "{{ aws_rds_current.instances[0].read_replica_db_instance_identifiers | default([]) }}"
+  when: aws_rds_current.instances | length > 0
+
 - name: Update RDS instance class before applying full configuration (workaround)
   block:
     - name: Update RDS instance class before applying full configuration (workaround)
@@ -73,43 +82,16 @@
   when: (aws_rds_current.instances|length) > 0 and aws_rds_current.instances[0].db_instance_class != aws_rds_instance_type
 
 
-# When we have known upgrade path:
-# we create temporary parameter group for specific db version
-# we upgrade database to next engine version
-# then we procees with usual rds provisioning - this will switch to normal parameter group
-# we remowe all created temporary parameter groups
-- name: Set upgrade plan
-  set_fact:
-    aws_rds_upgrade_plan: |
-      {{ aws_rds_upgrade_path[aws_rds_db_engine][
-        aws_rds_current.instances[0].engine_version.split('.')[0]
-        + "."
-        + aws_rds_current.instances[0].engine_version.split('.')[1]
-      ][aws_rds_db_engine_version] }}
-  when: |
-    aws_rds_upgrade_path[aws_rds_db_engine] is defined
-    and aws_rds_current.instances|length > 0
-    and aws_rds_upgrade_path[aws_rds_db_engine][
-      aws_rds_current.instances[0].engine_version.split('.')[0]
-      + "."
-      + aws_rds_current.instances[0].engine_version.split('.')[1]
-    ] is defined
-    and aws_rds_upgrade_path[aws_rds_db_engine][
-      aws_rds_current.instances[0].engine_version.split('.')[0]
-      + "."
-      + aws_rds_current.instances[0].engine_version.split('.')[1]
-    ][aws_rds_db_engine_version] is defined
+- name: Upgrade read replica RDS instances before primary
+  include_tasks: upgrade_instance.yml
+  loop: "{{ aws_rds_read_replica_instance_identifiers | default([]) }}"
+  loop_control:
+    loop_var: aws_rds_upgrade_target_identifier
 
-- name: Print upgrade plan
-  debug:
-    msg: |
-      Upgrade plan from {{ aws_rds_current.instances[0].engine_version }} to {{ aws_rds_db_engine_version }}
-        {{ aws_rds_current.instances[0].engine_version }} --> {{ " --> ".join(aws_rds_upgrade_plan) }}
-  when: aws_rds_upgrade_plan|length > 0
-
-- name: Upgrade MySQL/MariaDB RDS engine
-  include_tasks: upgrade_iteration.yml
-  loop: "{{ aws_rds_upgrade_plan }}"
+- name: Upgrade primary MySQL/MariaDB RDS engine
+  include_tasks: upgrade_instance.yml
+  vars:
+    aws_rds_upgrade_target_identifier: "{{ aws_rds_instance_name }}"
 
 - name: Create MySQL/MariaDB RDS
   rds_instance:
@@ -149,7 +131,7 @@
   retries: 600
   delay: 5
   until: _aws_rds_wait_upgrade_result.instances[0].db_instance_status == "available" or _aws_rds_wait_upgrade_result.instances[0].db_instance_status == "Storage-optimization"
-  when: (aws_rds_current.instances|length) > 0 and aws_rds_current.instances[0].engine_version != aws_rds_db_engine_version
+  when: (aws_rds_primary_current.instances|length) > 0 and aws_rds_primary_current.instances[0].engine_version != (aws_rds_db_engine_version | string)
 
 - name: Remove temporary parameter groups used for engine upgrade
   rds_param_group:

--- a/roles/cs.aws-rds/tasks/upgrade_instance.yml
+++ b/roles/cs.aws-rds/tasks/upgrade_instance.yml
@@ -1,0 +1,70 @@
+- name: Check current RDS configuration for upgrade target
+  rds_instance_info:
+    region: "{{ aws_region }}"
+    db_instance_identifier: "{{ aws_rds_upgrade_target_identifier }}"
+  register: aws_rds_upgrade_target_current
+
+- name: Derive upgrade families for current RDS target
+  set_fact:
+    _aws_rds_target_engine_version: "{{ aws_rds_db_engine_version | string }}"
+    _aws_rds_target_engine_version_parts: "{{ (aws_rds_db_engine_version | string).split('.') }}"
+    _aws_rds_current_engine_family: >-
+      {{ aws_rds_upgrade_target_current.instances[0].engine_version.split('.')[0:2] | join('.') }}
+    _aws_rds_target_engine_family: >-
+      {{ (aws_rds_db_engine_version | string).split('.')[0:2] | join('.') }}
+  when: aws_rds_upgrade_target_current.instances | length > 0
+
+# When we have known upgrade path:
+# we create temporary parameter group for specific db version
+# we upgrade database to next engine version
+# then we proceed with usual rds provisioning - this will switch to normal parameter group
+# we remove all created temporary parameter groups
+- name: Reset upgrade plan for current RDS target
+  set_fact:
+    aws_rds_upgrade_plan: []
+
+- name: Set upgrade plan for current RDS target
+  set_fact:
+    aws_rds_upgrade_plan: |
+      {{ aws_rds_upgrade_path[aws_rds_db_engine][
+        aws_rds_upgrade_target_current.instances[0].engine_version.split('.')[0]
+        + "."
+        + aws_rds_upgrade_target_current.instances[0].engine_version.split('.')[1]
+      ][_aws_rds_target_engine_version] }}
+  when: |
+    aws_rds_upgrade_path[aws_rds_db_engine] is defined
+    and aws_rds_upgrade_target_current.instances|length > 0
+    and _aws_rds_target_engine_version_parts | length >= 3
+    and aws_rds_upgrade_path[aws_rds_db_engine][
+      aws_rds_upgrade_target_current.instances[0].engine_version.split('.')[0]
+      + "."
+      + aws_rds_upgrade_target_current.instances[0].engine_version.split('.')[1]
+    ] is defined
+    and aws_rds_upgrade_path[aws_rds_db_engine][
+      aws_rds_upgrade_target_current.instances[0].engine_version.split('.')[0]
+      + "."
+      + aws_rds_upgrade_target_current.instances[0].engine_version.split('.')[1]
+    ][_aws_rds_target_engine_version] is defined
+
+- name: Set direct minor upgrade plan for current RDS target
+  set_fact:
+    aws_rds_upgrade_plan:
+      - "{{ _aws_rds_target_engine_version }}"
+  when:
+    - aws_rds_upgrade_target_current.instances | length > 0
+    - _aws_rds_target_engine_version_parts | length >= 3
+    - aws_rds_upgrade_target_current.instances[0].engine_version != _aws_rds_target_engine_version
+    - aws_rds_upgrade_plan | length == 0
+    - _aws_rds_current_engine_family == _aws_rds_target_engine_family
+
+- name: Print upgrade plan for current RDS target
+  debug:
+    msg: |
+      Upgrade plan for {{ aws_rds_upgrade_target_identifier }} from {{ aws_rds_upgrade_target_current.instances[0].engine_version }} to {{ aws_rds_db_engine_version }}
+        {{ aws_rds_upgrade_target_current.instances[0].engine_version }} --> {{ " --> ".join(aws_rds_upgrade_plan) }}
+  when: aws_rds_upgrade_plan|length > 0
+
+- name: Upgrade MySQL/MariaDB RDS engine for current target
+  include_tasks: upgrade_iteration.yml
+  loop: "{{ aws_rds_upgrade_plan }}"
+  when: aws_rds_upgrade_plan|length > 0

--- a/roles/cs.aws-rds/tasks/upgrade_iteration.yml
+++ b/roles/cs.aws-rds/tasks/upgrade_iteration.yml
@@ -1,6 +1,7 @@
 - name: Set upgrade parameters
   set_fact:
-    _aws_rds_upgrade_parameter_group: "{{ mageops_app_name }}-{{ item | replace('.', '-') }}-upgrade"
+    _aws_rds_upgrade_parameter_group: "{{ mageops_app_name }}-{{ aws_rds_upgrade_target_identifier }}-{{ item | replace('.', '-') }}-upgrade"
+    _aws_rds_upgrade_parameter_group_engine: "{{ aws_rds_db_engine }}{{ item.split('.')[0:2] | join('.') }}"
 
 - name: Schedule removal of temporary parameters
   set_fact:
@@ -9,7 +10,7 @@
 - name: Show step info
   debug:
     msg: |
-      Upgrading to {{ aws_rds_db_engine }} {{ item }}
+      Upgrading {{ aws_rds_upgrade_target_identifier }} to {{ aws_rds_db_engine }} {{ item }}
 
 - name: Create temporary RDS parameter group
   rds_param_group:
@@ -17,7 +18,7 @@
     region: "{{ aws_region }}"
     name: "{{ _aws_rds_upgrade_parameter_group }}"
     description: "{{ aws_rds_param_group_desc }}"
-    engine: "{{ aws_rds_db_engine }}{{ item }}"
+    engine: "{{ _aws_rds_upgrade_parameter_group_engine }}"
     tags: "{{ aws_tags_default }}"
     params: "{{ aws_rds_param_group_params | default(omit) }}"
 
@@ -25,7 +26,7 @@
   rds_instance:
     region: "{{ aws_region }}"
     publicly_accessible: "{{ aws_rds_publicly_accessible }}"
-    db_instance_identifier: "{{ aws_rds_instance_name }}"
+    db_instance_identifier: "{{ aws_rds_upgrade_target_identifier }}"
     engine: "{{ aws_rds_db_engine }}"
     db_parameter_group_name: "{{ _aws_rds_upgrade_parameter_group }}"
     engine_version: "{{ item }}"
@@ -58,8 +59,53 @@
 - name: Wait for active rds modifications to finish
   rds_instance_info:
     region: "{{ aws_region }}"
-    db_instance_identifier: "{{ aws_rds_instance_name }}"
+    db_instance_identifier: "{{ aws_rds_upgrade_target_identifier }}"
   register: aws_rds_current
   retries: 600
   delay: 5
   until: (aws_rds_current.instances|length) == 0 or aws_rds_current.instances[0].db_instance_status == "available"
+
+- name: Switch upgraded RDS target back to the standard parameter group
+  rds_instance:
+    region: "{{ aws_region }}"
+    publicly_accessible: "{{ aws_rds_publicly_accessible }}"
+    db_instance_identifier: "{{ aws_rds_upgrade_target_identifier }}"
+    engine: "{{ aws_rds_db_engine }}"
+    db_parameter_group_name: "{{ aws_rds_param_group_name }}"
+    engine_version: "{{ item }}"
+    allocated_storage: "{{ aws_rds_storage_size }}"
+    db_instance_class: "{{ aws_rds_instance_type }}"
+    master_username: "{{ mageops_mysql_root_user }}"
+    master_user_password: "{{ mageops_mysql_root_pass }}"
+    db_subnet_group_name: "{{ aws_rds_subnet_group_name }}"
+    vpc_security_group_ids: "{{ aws_rds_security_groups }}"
+    backup_retention_period: "{{ aws_rds_backup_retention }}"
+    preferred_backup_window: "{{ aws_rds_backup_window }}"
+    preferred_maintenance_window: "{{ aws_rds_maintenance_window }}"
+    auto_minor_version_upgrade: yes
+    allow_major_version_upgrade: yes
+    tags: "{{ aws_tags_default | combine(aws_tags_role_database, aws_tags_role_mysql_database, aws_tags_node_mysql) }}"
+    availability_zone: "{{ aws_rds_availability_zone }}"
+    storage_encrypted: "{{ aws_rds_storage_encrypt }}"
+    kms_key_id: "{{ aws_rds_encryption_key_name if aws_rds_storage_encrypt and aws_rds_dedicated_encryption_key else omit }}"
+    enable_performance_insights: "{{ aws_rds_performance_insights }}"
+    performance_insights_retention_period: "{{ aws_rds_performance_insights_retention_period if aws_rds_performance_insights else omit }}"
+    performance_insights_kms_key_id: "{{ aws_rds_encryption_key_name if aws_rds_storage_encrypt and aws_rds_dedicated_encryption_key else omit }}"
+    enable_cloudwatch_logs_exports: "{{ aws_rds_cloudwatch_logs_exports }}"
+    apply_immediately: yes
+    wait: yes
+
+- name: Wait for standard parameter group to be applied
+  rds_instance_info:
+    region: "{{ aws_region }}"
+    db_instance_identifier: "{{ aws_rds_upgrade_target_identifier }}"
+  register: aws_rds_current
+  retries: 600
+  delay: 5
+  until: >
+    (aws_rds_current.instances|length) == 0
+    or (
+      aws_rds_current.instances[0].db_instance_status == "available"
+      and aws_rds_current.instances[0].db_parameter_groups | selectattr('db_parameter_group_name', 'equalto', aws_rds_param_group_name) | list | length > 0
+      and aws_rds_current.instances[0].db_parameter_groups | selectattr('db_parameter_group_name', 'equalto', _aws_rds_upgrade_parameter_group) | list | length == 0
+    )


### PR DESCRIPTION
This PR exclude read replica from detecting main DB. Currently if there is read replica wrong DB can be passed to env.php