### PR TITLE
DEVOPS-452 - create uniq PHPIDE

### DIFF
--- a/roles/cs.nginx-magento/templates/magento_fastcgi_params.conf.j2
+++ b/roles/cs.nginx-magento/templates/magento_fastcgi_params.conf.j2
@@ -1,6 +1,6 @@
 fastcgi_param  PHP_VALUE        "memory_limit=${PHP_MEMORY_LIMIT} \n max_execution_time=${PHP_MAX_EXECUTION_TIME} \n ${PHP_EXTRA_VALUE}";
 fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
-fastcgi_param  PHP_IDE_CONFIG   serverName=$PROJ_NAME;
+fastcgi_param  PHP_IDE_CONFIG   serverName=$PROJ_NAME-{{ mageops_environment }};
 fastcgi_param  MAGE_MODE        $MAGE_MODE;
 fastcgi_param  ORIGINAL_URI     $request_uri;
 {% if nginx_magento_routing_configuration %}


### PR DESCRIPTION
Xdebug uses variable PHP_IDE_CONFIG to determine server name that is used for connecting to PhpStorm with specific configuration for this server. Each project and environment has its own configuration in IDE that is determined by this server name.

Currently each server (prod / test) uses the same server name in PHP_IDE_CONFIG which requires manual adjustments / config updates when a developer is switching with debugging from one env to another. To prevent that, server name must be unique for each env - in example by adding env suffix to server name in PHP_IDE_CONFIG.