### PR TITLE
Add option to list secured domains

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -762,6 +762,12 @@ mageops_https_enable: yes
 # Whether to password-protect the site using basic auth on varnish or nginx level
 # - this is standard procedure for every test system and preproduction environment
 mageops_secure_site: yes
+# Limit Varnish basic auth protection to exact domains. Leave empty to protect all domains.
+# Example:
+# mageops_secure_site_domains:
+#   - staging.example.com
+#   - protected.example.com
+mageops_secure_site_domains: []
 mageops_secure_site_user: "{{ mageops_project }}"
 # Mandatory! Set this per project in an encrypted credentials file
 # mageops_secure_site_password:

--- a/roles/cs.varnish/defaults/main.yml
+++ b/roles/cs.varnish/defaults/main.yml
@@ -1,5 +1,7 @@
 # Whether to password protect the website (basic auth)
 varnish_secure_site: yes
+# Limit basic auth protection to these exact domains. Leave empty to protect all domains.
+varnish_secure_site_domains: []
 
 # Credentials for basic auth protection
 varnish_secure_site_user: varnish

--- a/roles/cs.varnish/templates/vcl/subroutines/recv.vcl.j2
+++ b/roles/cs.varnish/templates/vcl/subroutines/recv.vcl.j2
@@ -240,6 +240,9 @@ if (req.url ~ "(?i)^/(media|static)/.*\.({{ varnish_allowed_extensions | join("|
         ! req.url ~ "(?i)^/(media|static)/.*\.(html|json|{{ varnish_allowed_extensions | join("|") }})(\?.*)?$"
         && ! req.url ~ "^/cron.php$"
         && ! req.url ~ "^/rest/.*$"
+    {% if varnish_secure_site_domains | length > 0 %}
+        && req.http.host ~ "(?i)^({{ varnish_secure_site_domains | map('regex_escape') | join('|') }})$"
+    {% endif %}
     {% for url in varnish_auth_bypass_urls %}
         && ! req.url ~ "^{{ url }}.*$"
     {% endfor %}

--- a/site.step-15-varnish.yml
+++ b/site.step-15-varnish.yml
@@ -62,6 +62,7 @@
       varnish_port: "{{ mageops_varnish_port }}"
       varnish_backend_port: "{{ mageops_varnish_backend_port }}"
       varnish_secure_site: "{{ mageops_secure_site }}"
+      varnish_secure_site_domains: "{{ mageops_secure_site_domains }}"
       varnish_secure_site_user: "{{ mageops_secure_site_user }}"
       varnish_secure_site_password: "{{ mageops_secure_site_password }}"
       varnish_trusted_ips: "{{ mageops_trusted_cidr_blocks + mageops_varnish_trusted_ips }}"


### PR DESCRIPTION
Now you can enabled basic auth for all domains. Sometimes there is a need to secure only new domain before go-live.